### PR TITLE
Voila rendering, map min_zoom, and analysis chart theming

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ if os.path.exists(proj_data):
 import logging
 
 import solara
+import solara.server.kernel_context as solara_kernel_context
 from sepal_ui.logger import setup_logging
 from sepal_ui.sepalwidgets.vue_app import MapApp, ThemeToggle
 from sepal_ui.solara import (
@@ -48,19 +49,24 @@ setup_solara_server()
 USE_GEE = False
 
 
+def _has_solara_kernel_context() -> bool:
+    """Return whether the current render is running under Solara server."""
+    return solara_kernel_context.has_current_context()
+
+
 @solara.lab.on_kernel_start
 def on_kernel_start():
     return setup_sessions()
 
 
 @solara.component
-# @with_sepal_sessions(module_name="sbae_app")
 def Page():
     """Main SBAE application page using MapApp layout."""
     # Notification system (pysepal): mount the provider once at the app root,
     # before any component that calls use_notifications(). Kept in the same page
     # as MapApp so the task pill can track the right-panel offset.
-    NotificationProvider()
+    if _has_solara_kernel_context():
+        NotificationProvider()
     ErrorToastBridge()
 
     app_model = AppModel()

--- a/component/widget/analysis_chart.py
+++ b/component/widget/analysis_chart.py
@@ -53,6 +53,10 @@ def AreaEstimateChart(results: dict, unit: str, theme_toggle=None):
     )
 
     option = Option(
+        # Transparent background (alpha 00) so the chart blends into the panel
+        # instead of showing ECharts' built-in dark theme #100c2a fill. Matches
+        # the summary pie/precision charts in summary.py.
+        backgroundColor="#1e1e1e00",
         title=Title(
             text="Error-adjusted area by class",
             left="center",

--- a/component/widget/analysis_results.py
+++ b/component/widget/analysis_results.py
@@ -12,7 +12,7 @@ def _unit_label(unit: str) -> str:
 
 
 @solara.component
-def AnalysisResultsView():
+def AnalysisResultsView(theme_toggle=None):
     results = app_state.analysis_results.value
     if not results:
         return
@@ -27,7 +27,7 @@ def AnalysisResultsView():
         _Accuracy(results)
         from component.widget.analysis_chart import AreaEstimateChart  # Task 10
 
-        AreaEstimateChart(results, unit)
+        AreaEstimateChart(results, unit, theme_toggle=theme_toggle)
         _Downloads()
 
 

--- a/component/widget/analysis_tab.py
+++ b/component/widget/analysis_tab.py
@@ -146,7 +146,7 @@ def CurrentTableDisplay(title: str, df, name: str = "", on_clear=None):
 
 
 @solara.component
-def AnalysisPanel():
+def AnalysisPanel(theme_toggle=None):
     """Full analysis panel filling the Analysis tab."""
     reading = solara.use_reactive(False)
     ref_path = solara.use_reactive(None)
@@ -271,7 +271,7 @@ def AnalysisPanel():
         # Results section, always present like the design's Summary: the worked
         # output once ready, otherwise a hint on what to do next.
         if app_state.analysis_results.value is not None:
-            AnalysisResultsView()
+            AnalysisResultsView(theme_toggle=theme_toggle)
         elif not ref_loaded:
             solara.Info(
                 "Upload a reference table (or load the example data) to run the "

--- a/component/widget/map.py
+++ b/component/widget/map.py
@@ -1,6 +1,7 @@
 import logging
 
 import ipyleaflet
+import solara
 from localtileserver import TileClient, get_leaflet_tile_layer
 from sepal_ui.mapping import SepalMap
 from sepal_ui.sepalwidgets.vue_app import ThemeToggle
@@ -26,6 +27,21 @@ def _build_class_colormap(class_colors: dict) -> dict:
     for code, hex_color in class_colors.items():
         colormap[int(code)] = (*_hex_to_rgb(hex_color), 255)
     return colormap
+
+
+def _tile_client_kwargs_for_runtime(is_voila: bool | None = None) -> dict:
+    """Return TileClient browser URL options for the current runtime."""
+    if is_voila is None:
+        is_voila = solara.util.is_running_in_voila()
+
+    if not is_voila:
+        return {}
+
+    return {
+        "client_host": "127.0.0.1",
+        "client_port": True,
+        "cors_all": True,
+    }
 
 
 class SbaeMap(SepalMap):
@@ -102,7 +118,7 @@ class SbaeMap(SepalMap):
                 fit_bounds=fit_bounds,
             )
 
-        client = TileClient(path)
+        client = TileClient(path, **_tile_client_kwargs_for_runtime())
         layer = get_leaflet_tile_layer(
             client,
             colormap=colormap_arg,

--- a/component/widget/map.py
+++ b/component/widget/map.py
@@ -47,8 +47,10 @@ def _tile_client_kwargs_for_runtime(is_voila: bool | None = None) -> dict:
 class SbaeMap(SepalMap):
     """SBAE Map class extending SepalMap for map visualization and interactions."""
 
-    def __init__(self, theme_toggle: ThemeToggle, gee: bool = False):
-        super().__init__(fullscreen=True, theme_toggle=theme_toggle, gee=gee)
+    def __init__(self, theme_toggle: ThemeToggle, gee: bool = False, min_zoom: int = 5):
+        super().__init__(
+            fullscreen=True, theme_toggle=theme_toggle, gee=gee, min_zoom=min_zoom
+        )
 
         self.classification_layer = None
         self.sample_points_layer = None

--- a/component/widget/sample_configuration.py
+++ b/component/widget/sample_configuration.py
@@ -157,7 +157,7 @@ def SampleConfiguration(sbae_map=None, theme_toggle=None):
                 point_generation_controller=point_generation_controller,
             )
         else:
-            AnalysisTab()
+            AnalysisTab(theme_toggle=theme_toggle)
 
 
 @solara.component
@@ -257,11 +257,11 @@ def DesignOutputs(sbae_map=None, theme_toggle=None, point_generation_controller=
 
 
 @solara.component
-def AnalysisTab():
+def AnalysisTab(theme_toggle=None):
     """Accuracy-assessment analysis (area estimation + accuracies)."""
     from component.widget.analysis_tab import AnalysisPanel
 
-    AnalysisPanel()
+    AnalysisPanel(theme_toggle=theme_toggle)
 
 
 @solara.component

--- a/tests/test_app_page_render.py
+++ b/tests/test_app_page_render.py
@@ -10,6 +10,7 @@ real ``Page`` inside a virtual kernel context, which mutates process-global
 state (singletons, kernel context) that would otherwise leak into other tests.
 """
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -30,11 +31,30 @@ solara.render(app.Page(), handle_error=False)
 print("PAGE_RENDER_OK")
 """
 
+_WIDGET_RENDER_SCRIPT = """
+import solara
+import solara.server.kernel_context as kc
+import app
 
-def test_page_renders_under_kernel_context():
+solara.render(app.Page(), handle_error=False)
+assert not kc.has_current_context()
+print("PAGE_WIDGET_RENDER_OK")
+"""
+
+
+def _render_env(tmp_path):
+    return {
+        **os.environ,
+        "HOME": str(tmp_path),
+        "MPLCONFIGDIR": str(tmp_path / "matplotlib"),
+    }
+
+
+def test_page_renders_under_kernel_context(tmp_path):
     result = subprocess.run(
         [sys.executable, "-c", _RENDER_SCRIPT],
         cwd=str(_REPO_ROOT),
+        env=_render_env(tmp_path),
         capture_output=True,
         text=True,
         timeout=120,
@@ -42,3 +62,17 @@ def test_page_renders_under_kernel_context():
 
     assert result.returncode == 0, result.stderr[-3000:]
     assert "PAGE_RENDER_OK" in result.stdout
+
+
+def test_page_renders_without_solara_server_context(tmp_path):
+    result = subprocess.run(
+        [sys.executable, "-c", _WIDGET_RENDER_SCRIPT],
+        cwd=str(_REPO_ROOT),
+        env=_render_env(tmp_path),
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stderr[-3000:]
+    assert "PAGE_WIDGET_RENDER_OK" in result.stdout

--- a/tests/test_map_colormap.py
+++ b/tests/test_map_colormap.py
@@ -1,6 +1,6 @@
 """The categorical colormap must show every sampleable class (incl. 0 and >255)."""
 
-from component.widget.map import _build_class_colormap
+from component.widget.map import _build_class_colormap, _tile_client_kwargs_for_runtime
 
 
 def test_colormap_colors_class_zero():
@@ -19,3 +19,20 @@ def test_colormap_leaves_unknown_values_transparent():
     cm = _build_class_colormap({5: "#00ff00"})
     assert cm[7] == (0, 0, 0, 0)
     assert cm[5] == (0, 255, 0, 255)
+
+
+def test_tile_client_kwargs_force_loopback_url_in_voila():
+    assert _tile_client_kwargs_for_runtime(is_voila=True) == {
+        "client_host": "127.0.0.1",
+        "client_port": True,
+        "cors_all": True,
+    }
+
+
+def test_tile_client_kwargs_keep_localtileserver_defaults_outside_voila():
+    assert _tile_client_kwargs_for_runtime(is_voila=False) == {}
+
+
+def test_tile_client_kwargs_uses_solara_voila_detector(monkeypatch):
+    monkeypatch.setattr("component.widget.map.solara.util.is_running_in_voila", lambda: True)
+    assert _tile_client_kwargs_for_runtime()["client_host"] == "127.0.0.1"


### PR DESCRIPTION
Follow-up UI work on the sample-design branch, on top of the (already merged) PR #10.

Three commits:

- **Support Voila rendering** — runtime-aware tile client URLs so the app renders under Voila.
- **Default map `min_zoom` of 5** — `SbaeMap` now floors zoom-out at level 5 (roughly continental), overridable via the constructor. `SepalMap` never set `min_zoom`, so it previously inherited ipyleaflet's `0`.
- **Match analysis chart theming to the summary charts** — thread the app `theme_toggle` down to `AreaEstimateChart` and set a transparent `backgroundColor` (`#1e1e1e00`), so it stops showing ECharts' built-in dark-theme `#100c2a` fill and tracks the theme toggle in lockstep with the summary pie/precision charts.

Tests: `111 passed`.
