### PR TITLE
Analysis dashboard and PMTiles sample-point rendering

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,7 +31,7 @@ from solara.lab.components.theming import theme
 
 from component.model.app_model import AppModel
 from component.tile.upload import RasterMapWatcher
-from component.widget.map import SbaeMap
+from component.widget.map import PointsLegend, SbaeMap
 from component.widget.notification_bridge import ErrorToastBridge
 from component.widget.sample_configuration import SampleConfiguration
 
@@ -108,6 +108,8 @@ def Page():
     sbae_map = SbaeMap(theme_toggle=theme_toggle, gee=USE_GEE)
 
     RasterMapWatcher(sbae_map)
+    # Floating legend overlay for the sample/reference points (bottom-center).
+    PointsLegend()
 
     steps_data = [
         {

--- a/app.py
+++ b/app.py
@@ -48,6 +48,35 @@ setup_solara_server()
 USE_GEE = False
 
 
+@solara.component
+def _TileLoopbackBridge():
+    """Tunnel localtileserver's localhost tile URLs over the widget comm.
+
+    When the app is served behind a reverse proxy -- ``run-solara --serve``
+    (tailscale serve) or SEPAL -- the raster tile server's
+    ``http://127.0.0.1:<port>`` URL is unreachable from the browser, which only
+    sees the proxied app origin. This mounts jupyter_loopback's anywidget comm
+    bridge; its frontend reroutes those requests over the same websocket Solara
+    already uses (localtileserver's ``get_leaflet_tile_layer`` registers each
+    tile port via ``enable_for_port``). Gated on ``LOCALTILESERVER_COMM_BRIDGE``
+    so plain local runs keep the faster direct-HTTP tile path.
+    """
+    enabled = bool(os.environ.get("LOCALTILESERVER_COMM_BRIDGE"))
+
+    def _enable():
+        if not enabled:
+            return None
+        import jupyter_loopback
+
+        return jupyter_loopback.enable_comm_bridge(display=False)
+
+    bridge = solara.use_memo(_enable, [])
+    if bridge is not None:
+        # Mount the (invisible) bridge widget so its ESM loads and installs the
+        # window.__jupyter_loopback__ interceptor in the browser.
+        solara.display(bridge)
+
+
 @solara.lab.on_kernel_start
 def on_kernel_start():
     return setup_sessions()
@@ -57,19 +86,23 @@ def on_kernel_start():
 # @with_sepal_sessions(module_name="sbae_app")
 def Page():
     """Main SBAE application page using MapApp layout."""
-    # Notification system (pysepal): mount the provider once at the app root,
-    # before any component that calls use_notifications(). Kept in the same page
-    # as MapApp so the task pill can track the right-panel offset.
-    NotificationProvider()
-    ErrorToastBridge()
-
-    app_model = AppModel()
-
-    setup_theme_colors()
     # pysepal's MapApp requires a per-kernel ThemeState. In a local (non-SEPAL)
     # run the session manager is active but has no theme_state component, so
     # get_current_theme_state() would raise; provide an explicit one instead.
     theme_state = solara.use_memo(ThemeState, [])
+
+    # Notification system (pysepal): mount the provider once at the app root,
+    # before any component that calls use_notifications(). Kept in the same page
+    # as MapApp so the task pill can track the right-panel offset. It takes the
+    # same ThemeState as MapApp: without it the provider falls back to a
+    # process-local default and the toasts/pill stay light under a dark app.
+    NotificationProvider(theme_state=theme_state)
+    ErrorToastBridge()
+    _TileLoopbackBridge()
+
+    app_model = AppModel()
+
+    setup_theme_colors()
     theme_toggle = ThemeToggle()
     theme_toggle.observe(lambda e: setattr(theme, "dark", e["new"]), "dark")
     sbae_map = SbaeMap(theme_toggle=theme_toggle, gee=USE_GEE)

--- a/component/analysis/service.py
+++ b/component/analysis/service.py
@@ -75,6 +75,41 @@ class AnalysisService:
         )
 
     @staticmethod
+    def inputs_signature(app_state) -> tuple:
+        """A cheap, stable fingerprint of every input that affects the result.
+
+        The Analysis tab computes results only on an explicit Calculate and
+        stores this signature alongside them; when the live inputs no longer
+        produce the same signature, the shown dashboard is stale and hidden
+        until the user recalculates. Uses table shapes + names (not full
+        content) to stay cheap while still changing whenever a table is
+        loaded/cleared/replaced or the map derivation adds a ``map_code``
+        column.
+        """
+        import json
+
+        def _shape(df):
+            if df is None or getattr(df, "empty", True):
+                return (0, 0)
+            return (int(df.shape[0]), int(df.shape[1]))
+
+        mapping = app_state.analysis_column_mapping.value or {}
+        filt = app_state.analysis_filter.value
+        return (
+            app_state.analysis_area_source.value,
+            tuple(sorted((str(k), str(v)) for k, v in mapping.items())),
+            float(app_state.analysis_confidence_level.value),
+            str(app_state.analysis_area_unit.value),
+            json.dumps(filt, sort_keys=True, default=str) if filt else None,
+            app_state.analysis_reference_name.value,
+            _shape(app_state.analysis_reference_df.value),
+            app_state.analysis_area_name.value,
+            _shape(app_state.analysis_area_df.value),
+            _shape(app_state.area_data.value),
+            app_state.analysis_classification_path.value,
+        )
+
+    @staticmethod
     def is_ready(app_state) -> bool:
         try:
             inputs = AnalysisService.create_inputs_from_state(app_state)

--- a/component/analysis/service.py
+++ b/component/analysis/service.py
@@ -44,6 +44,10 @@ class AnalysisService:
                 if raw_area is not None and not raw_area.empty
                 else pd.DataFrame()
             )
+        elif app_state.analysis_area_source.value == "map":
+            # raster-derived area table is already canonical map_code / map_area
+            raw_area = app_state.analysis_area_df.value
+            area = raw_area.copy() if raw_area is not None else pd.DataFrame()
         else:
             # design side already yields map_code / map_area
             area = app_state.area_data.value

--- a/component/model/state_manager.py
+++ b/component/model/state_manager.py
@@ -574,6 +574,7 @@ class AppState:
         self.analysis_reference_df.value = pd.DataFrame()
         self.analysis_area_source.value = "design"
         self.analysis_area_df.value = pd.DataFrame()
+        self.analysis_classification_path.value = None
         self.analysis_column_mapping.value = {}
         self.analysis_filter.value = None
         self.analysis_confidence_level.value = 95.0

--- a/component/model/state_manager.py
+++ b/component/model/state_manager.py
@@ -82,8 +82,13 @@ class AppState:
 
         # --- Analysis (accuracy assessment) ---
         self.analysis_reference_df = solara.reactive(pd.DataFrame())
-        self.analysis_area_source = solara.reactive("design")  # "design" | "upload"
+        self.analysis_area_source = solara.reactive(
+            "design"
+        )  # "design" | "upload" | "map"
         self.analysis_area_df = solara.reactive(pd.DataFrame())
+        self.analysis_classification_path = solara.reactive(
+            None
+        )  # raster path for "map" source
         self.analysis_column_mapping = solara.reactive({})
         self.analysis_filter = solara.reactive(None)
         self.analysis_confidence_level = solara.reactive(95.0)

--- a/component/model/state_manager.py
+++ b/component/model/state_manager.py
@@ -35,6 +35,10 @@ class AppState:
         self.aoi_computing = solara.reactive(False)
         # Color palette extracted from raster or default
         self.class_colors = solara.reactive({})
+        # On-map points legend: {label: hex}, composed from the point layers
+        # shown (see SbaeMap._refresh_points_legend); rendered by PointsLegend.
+        # (Distinct from accuracy's map_legend/ref_legend class-code lists.)
+        self.points_legend = solara.reactive({})
         # Expected User's Accuracy per class (EUA)
         self.expected_user_accuracies = solara.reactive({})
         # Global high and low EUA values

--- a/component/model/state_manager.py
+++ b/component/model/state_manager.py
@@ -94,6 +94,10 @@ class AppState:
         self.analysis_confidence_level = solara.reactive(95.0)
         self.analysis_area_unit = solara.reactive("ha")  # "ha" | "m2"
         self.analysis_results = solara.reactive(None)
+        # Signature of the inputs that produced analysis_results. Results are only
+        # (re)computed by an explicit Calculate action; when the live inputs no
+        # longer match this signature the dashboard is treated as stale and hidden.
+        self.analysis_results_signature = solara.reactive(None)
         self.analysis_status = solara.reactive("")
         # Display names for the loaded analysis tables (mirrors uploaded_file_info
         # for the design tab): shown by CurrentTableDisplay once a CSV is loaded.
@@ -565,9 +569,15 @@ class AppState:
         # Clear analysis data
         self.clear_analysis_data()
 
-    def set_analysis_results(self, results: Dict):
-        """Store analysis results (AnalysisResults.to_dict())."""
+    def set_analysis_results(self, results: Dict, signature=None):
+        """Store analysis results and the inputs signature that produced them.
+
+        The signature lets the Analysis tab hide the dashboard once any input
+        changes (results are only recomputed on an explicit Calculate). Passing
+        ``None`` (the default) clears both, blanking the dashboard.
+        """
         self.analysis_results.value = results
+        self.analysis_results_signature.value = signature
 
     def clear_analysis_data(self):
         """Reset all analysis inputs and outputs."""
@@ -580,6 +590,7 @@ class AppState:
         self.analysis_confidence_level.value = 95.0
         self.analysis_area_unit.value = "ha"
         self.analysis_results.value = None
+        self.analysis_results_signature.value = None
         self.analysis_status.value = ""
         self.analysis_reference_name.value = ""
         self.analysis_area_name.value = ""

--- a/component/scripts/accuracy.py
+++ b/component/scripts/accuracy.py
@@ -153,6 +153,26 @@ def overall_accuracy(pij: pd.DataFrame) -> float:
     return float(np.trace(m.values))
 
 
+def derive_from_classification(reference_df, mapping, raster_path):
+    """Fill map_code by sampling a raster and compute the per-class area table.
+
+    Returns (reference_df_with_map_code, area_df, dropped_count). The map wins:
+    any existing map_code column is overwritten by the sampled value.
+    """
+    from component.scripts.geospatial import (
+        compute_area_from_raster,
+        extract_map_codes,
+    )
+
+    x_col = mapping.get("x")
+    y_col = mapping.get("y")
+    if not x_col or not y_col:
+        raise ValueError("Classification-map analysis requires x/y column mapping.")
+    ref_out, dropped = extract_map_codes(reference_df, raster_path, x_col, y_col)
+    area_df = compute_area_from_raster(raster_path)
+    return ref_out, area_df, dropped
+
+
 def convert_area(value: float, unit: str) -> float:
     """Convert a native (m2) area for display. 'ha' -> /10000; else identity."""
     if unit == "ha":

--- a/component/scripts/geospatial.py
+++ b/component/scripts/geospatial.py
@@ -13,6 +13,7 @@ import numpy as np
 import pandas as pd
 import rasterio
 from rasterio.transform import xy
+from rasterio.warp import transform as warp_transform
 from rasterio.windows import Window
 from shapely.geometry import Point
 
@@ -1243,3 +1244,42 @@ def get_file_info(file_path: str) -> Dict:
         info["error"] = str(e)
 
     return info
+
+
+def extract_map_codes(
+    reference_df: pd.DataFrame,
+    raster_path: str,
+    x_col: str,
+    y_col: str,
+    points_crs: str = "EPSG:4326",
+) -> "tuple[pd.DataFrame, int]":
+    """Sample a classification raster at each reference point to fill map_code.
+
+    Reprojects the (x_col, y_col) points from points_crs to the raster CRS,
+    samples band 1, and returns (df_with_map_code, dropped_count). Rows whose
+    point falls outside the raster footprint or on the nodata value are dropped.
+    """
+    df = reference_df.copy()
+    xs = df[x_col].astype(float).to_numpy()
+    ys = df[y_col].astype(float).to_numpy()
+    with rasterio.open(raster_path) as src:
+        if src.crs is not None and points_crs and str(src.crs) != str(points_crs):
+            rxs, rys = warp_transform(points_crs, src.crs, xs.tolist(), ys.tolist())
+        else:
+            rxs, rys = xs.tolist(), ys.tolist()
+        left, bottom, right, top = src.bounds
+        nodata = src.nodata
+        pts = list(zip(rxs, rys))
+        codes = []
+        for (x, y), val in zip(pts, src.sample(pts)):
+            v = val[0]
+            inside = left <= x <= right and bottom <= y <= top
+            if inside and not (nodata is not None and v == nodata):
+                codes.append(int(v))
+            else:
+                codes.append(None)
+    df["map_code"] = codes
+    dropped = int(df["map_code"].isna().sum())
+    df = df[df["map_code"].notna()].copy()
+    df["map_code"] = df["map_code"].astype(int)
+    return df, dropped

--- a/component/scripts/geospatial.py
+++ b/component/scripts/geospatial.py
@@ -194,6 +194,33 @@ def extract_raster_colormap(file_path: str) -> Dict[int, str]:
     return colors
 
 
+# ECharts default colors -- the categorical fallback palette.
+_DEFAULT_PALETTE = [
+    "#5470c6",
+    "#91cc75",
+    "#fac858",
+    "#ee6666",
+    "#73c0de",
+    "#3ba272",
+    "#fc8452",
+    "#9a60b4",
+    "#ea7ccc",
+]
+
+
+def palette_for_codes(class_codes: List[int]) -> Dict[int, str]:
+    """Assign a stable hex colour to each class code by sorted position.
+
+    Deterministic and file-free: the same set of codes always yields the same
+    colours (used when no real class palette exists, e.g. a reference CSV that
+    never touched a raster). Cycles the base palette when codes outnumber it.
+    """
+    return {
+        code: _DEFAULT_PALETTE[idx % len(_DEFAULT_PALETTE)]
+        for idx, code in enumerate(sorted(class_codes))
+    }
+
+
 def get_color_palette(file_path: str, class_codes: List[int]) -> Dict[int, str]:
     """Get color palette for given class codes, extracting from file if possible.
 
@@ -204,35 +231,16 @@ def get_color_palette(file_path: str, class_codes: List[int]) -> Dict[int, str]:
     Returns:
         Dictionary mapping class codes to hex color strings
     """
-    # Default color palette (ECharts default colors)
-    default_colors = [
-        "#5470c6",
-        "#91cc75",
-        "#fac858",
-        "#ee6666",
-        "#73c0de",
-        "#3ba272",
-        "#fc8452",
-        "#9a60b4",
-        "#ea7ccc",
-    ]
-
-    # Try to extract colors from raster file
     extracted_colors = {}
     if is_raster_file(file_path):
         extracted_colors = extract_raster_colormap(file_path)
 
-    # Build color mapping for each class code
-    color_map = {}
-    for idx, class_code in enumerate(sorted(class_codes)):
-        if class_code in extracted_colors:
-            # Use extracted color if available
-            color_map[class_code] = extracted_colors[class_code]
-        else:
-            # Fall back to default palette
-            color_map[class_code] = default_colors[idx % len(default_colors)]
-
-    return color_map
+    # Extracted colors win; anything the file doesn't cover falls back to the
+    # deterministic categorical palette (same sorted-index assignment).
+    fallback = palette_for_codes(class_codes)
+    return {
+        code: extracted_colors.get(code, fallback[code]) for code in sorted(class_codes)
+    }
 
 
 def compute_area_from_raster(file_path: str) -> pd.DataFrame:

--- a/component/scripts/geospatial.py
+++ b/component/scripts/geospatial.py
@@ -183,7 +183,7 @@ def extract_raster_colormap(file_path: str) -> Dict[int, str]:
                 for class_code, rgba in colormap.items():
                     # Convert RGBA tuple to hex color
                     # rasterio returns values in 0-255 range
-                    r, g, b, a = rgba
+                    r, g, b, _ = rgba
                     hex_color = f"#{r:02x}{g:02x}{b:02x}"
                     colors[class_code] = hex_color
 
@@ -1252,12 +1252,18 @@ def extract_map_codes(
     x_col: str,
     y_col: str,
     points_crs: str = "EPSG:4326",
+    drop_missing: bool = True,
 ) -> "tuple[pd.DataFrame, int]":
     """Sample a classification raster at each reference point to fill map_code.
 
     Reprojects the (x_col, y_col) points from points_crs to the raster CRS,
-    samples band 1, and returns (df_with_map_code, dropped_count). Rows whose
-    point falls outside the raster footprint or on the nodata value are dropped.
+    samples band 1, and returns (df_with_map_code, dropped_count). Points that
+    fall outside the raster footprint or on the nodata value are "missing".
+
+    ``drop_missing=True`` (default, the analysis path) drops those rows.
+    ``drop_missing=False`` (the design path, where the sample is fixed) keeps
+    every row and leaves missing points at their prior ``map_code`` (or 0).
+    In both cases ``dropped_count`` reports how many were missing.
     """
     df = reference_df.copy()
     xs = df[x_col].astype(float).to_numpy()
@@ -1279,7 +1285,14 @@ def extract_map_codes(
             else:
                 codes.append(None)
     df["map_code"] = codes
-    dropped = int(df["map_code"].isna().sum())
-    df = df[df["map_code"].notna()].copy()
+    missing = df["map_code"].isna()
+    dropped = int(missing.sum())
+    if drop_missing:
+        df = df[~missing].copy()
+    else:
+        # Keep every point; unsampleable ones fall back to their prior map_code
+        # (0 for freshly-generated design points) instead of being dropped.
+        fallback = reference_df["map_code"] if "map_code" in reference_df.columns else 0
+        df["map_code"] = df["map_code"].where(~missing, fallback)
     df["map_code"] = df["map_code"].astype(int)
     return df, dropped

--- a/component/scripts/geospatial.py
+++ b/component/scripts/geospatial.py
@@ -1267,13 +1267,13 @@ def extract_map_codes(
             rxs, rys = warp_transform(points_crs, src.crs, xs.tolist(), ys.tolist())
         else:
             rxs, rys = xs.tolist(), ys.tolist()
-        left, bottom, right, top = src.bounds
         nodata = src.nodata
         pts = list(zip(rxs, rys))
         codes = []
-        for (x, y), val in zip(pts, src.sample(pts)):
+        for (x, y), val in zip(pts, src.sample(pts, indexes=1)):
+            row, col = src.index(x, y)
             v = val[0]
-            inside = left <= x <= right and bottom <= y <= top
+            inside = 0 <= row < src.height and 0 <= col < src.width
             if inside and not (nodata is not None and v == nodata):
                 codes.append(int(v))
             else:

--- a/component/scripts/logging_config.py
+++ b/component/scripts/logging_config.py
@@ -1,0 +1,36 @@
+"""Quiet the chatty tile-server access/debug logs.
+
+The raster path (``localtileserver``) and the sample-points path
+(``vectortileserver``) each run their own ``uvicorn`` instance. Both emit an
+``INFO`` access line per tile request (hundreds while panning a map), and
+``vectortileserver``'s ``"VECTORTILES"`` logger runs at ``DEBUG``.
+
+``uvicorn`` re-applies its own logging config each time a server starts, so
+setting these levels once at import does not stick. Call
+:func:`quiet_tile_server_logs` right AFTER a tile server comes up (i.e. just
+after constructing a ``TileClient``); it is idempotent, so calling it per client
+is fine and keeps the level pinned no matter which server booted last.
+"""
+
+import logging
+
+# uvicorn's shared access/error loggers (process-global across every uvicorn
+# instance), vectortileserver's "VECTORTILES" logger, and the two libraries'
+# module loggers.
+_NOISY_LOGGERS = (
+    "uvicorn.access",
+    "uvicorn.error",
+    "VECTORTILES",
+    "vectortileserver",
+    "localtileserver",
+)
+
+
+def quiet_tile_server_logs(level: int = logging.WARNING) -> None:
+    """Raise the tile-server loggers to ``level`` (default WARNING).
+
+    Suppresses per-tile uvicorn access lines and vectortileserver's DEBUG
+    chatter while leaving real warnings/errors visible.
+    """
+    for name in _NOISY_LOGGERS:
+        logging.getLogger(name).setLevel(level)

--- a/component/scripts/logging_config.py
+++ b/component/scripts/logging_config.py
@@ -13,6 +13,19 @@ is fine and keeps the level pinned no matter which server booted last.
 """
 
 import logging
+import warnings
+
+# rio-tiler emits ``NoOverviewWarning`` once per tile when a source raster has no
+# overviews. The raster-add paths now build overviews up front
+# (``SbaeMap.add_class_raster`` -> ``prepare_for_tiles``), so this warning is
+# non-actionable noise here; silence it so any raster that still slips through a
+# fallback path cannot flood the logs with hundreds of identical lines.
+try:
+    from rio_tiler.errors import NoOverviewWarning
+
+    warnings.filterwarnings("ignore", category=NoOverviewWarning)
+except Exception:  # pragma: no cover - rio_tiler is always present via localtileserver
+    pass
 
 # uvicorn's shared access/error loggers (process-global across every uvicorn
 # instance), vectortileserver's "VECTORTILES" logger, and the two libraries'

--- a/component/scripts/tiling.py
+++ b/component/scripts/tiling.py
@@ -175,8 +175,10 @@ def prepare_for_tiles(
     rep = analyze_tif(path)
     categorical = rep["categorical_guess"]
     resamp = "NEAREST" if categorical else "AVERAGE"
-    need_reproj = _needs_reproject(rio.open(path), 3857) if warp_to_3857 else False
-    good_enough = rep["tiled"] and _has_overviews(rio.open(path)) and not need_reproj
+    # Open once (context-managed) instead of leaking a handle per rio.open call.
+    with rio.open(path) as _ds:
+        need_reproj = _needs_reproject(_ds, 3857) if warp_to_3857 else False
+        good_enough = rep["tiled"] and _has_overviews(_ds) and not need_reproj
 
     if good_enough and not force:
         return {"path": path, "report": rep}

--- a/component/scripts/vector_tiles.py
+++ b/component/scripts/vector_tiles.py
@@ -8,6 +8,7 @@ import is confined to ``_default_client_factory`` -- the ONE seam that touches
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -18,6 +19,19 @@ import pandas as pd
 from component.scripts.logging_config import quiet_tile_server_logs
 
 logger = logging.getLogger("sbae.vector_tiles")
+
+# Point styling. Sample/reference points stay a single neutral colour with a
+# white halo so they read over a colourful classification map; analysis points
+# encode only agreement (green = map matches reference, red = it doesn't).
+SAMPLE_POINT_COLOR = "#000000"
+POINT_HALO_COLOR = "#ffffff"
+CORRECT_COLOR = "#2e7d32"
+INCORRECT_COLOR = "#c62828"
+REFERENCE_NEUTRAL_COLOR = "#607d8b"
+
+# Feature properties coerced to int for clean JSON *and* so protomaps-leaflet's
+# strict-equality ``==`` filter matches the numeric tile values.
+_INT_PROPS = ("map_code", "ref_code", "correct")
 
 
 def points_to_geojson(
@@ -30,7 +44,8 @@ def points_to_geojson(
 
     Coordinates are written ``[lon, lat]`` (GeoJSON order). Only the columns in
     ``props`` that are present in ``df`` are copied onto each feature; NaN
-    values are skipped. ``map_code`` is coerced to ``int`` for clean JSON.
+    values are skipped. Categorical fields (see ``_INT_PROPS``) are coerced to
+    ``int`` for clean JSON.
     """
     present = [p for p in props if p in df.columns]
     features = []
@@ -40,7 +55,7 @@ def points_to_geojson(
             value = row[p]
             if pd.isna(value):
                 continue
-            properties[p] = int(value) if p == "map_code" else value
+            properties[p] = int(value) if p in _INT_PROPS else value
         features.append(
             {
                 "type": "Feature",
@@ -54,6 +69,27 @@ def points_to_geojson(
     return {"type": "FeatureCollection", "features": features}
 
 
+def _circle_layer(
+    idx: int, source_layer: str, filt, *, fill, stroke, radius, stroke_width, opacity
+) -> dict:
+    layer = {
+        "id": f"sample-points-circle-{idx}",
+        "type": "circle",
+        "source": "pmtiles_source",
+        "source-layer": source_layer,
+        "paint": {
+            "circle-radius": radius,
+            "circle-color": fill,
+            "circle-stroke-color": stroke,
+            "circle-stroke-width": stroke_width,
+            "circle-opacity": opacity,
+        },
+    }
+    if filt is not None:
+        layer["filter"] = filt
+    return layer
+
+
 def build_point_style(
     pmtiles_url: str,
     class_colors: dict,
@@ -65,41 +101,52 @@ def build_point_style(
     stroke_color: str = "#ffffff",
     stroke_width: int = 1,
     opacity: float = 0.85,
+    categories: list | None = None,
 ) -> dict:
-    """Build a MapLibre style with one categorized ``circle`` layer.
+    """Build a MapLibre-style dict of flat-colour ``circle`` layers, one per class.
 
-    ``circle-color`` is a ``["match", ["get", color_field], code, hex, ...,
-    default]`` expression from ``class_colors``. Empty ``class_colors`` yields a
-    plain ``default_color`` (no match expression).
+    The PMTiles renderer (protomaps-leaflet, via ipyleaflet) does NOT evaluate
+    MapLibre data-driven expressions for colours -- ``circle-color`` must be a
+    plain colour string (or a JS function, which can't cross the JSON style
+    trait). An expression array is passed through untouched and the canvas falls
+    back to solid black. So categorical colouring is done the protomaps-leaflet
+    way: one flat-colour circle layer per category value, each behind a legacy
+    ``["==", color_field, code]`` filter (the only filter form protomaps-leaflet
+    understands).
+
+    ``categories`` lists the codes to emit, derived from the data actually
+    present. Empty ``class_colors`` yields a single unfiltered ``default_color``
+    layer -- the uniform look used for the design sample points.
     """
-    if class_colors:
-        circle_color = ["match", ["get", color_field]]
-        for code, hex_color in class_colors.items():
-            circle_color.extend([int(code), hex_color])
-        circle_color.append(default_color)
+    common = dict(radius=radius, stroke_width=stroke_width, opacity=opacity)
+    layers = []
+
+    if not class_colors:
+        layers.append(
+            _circle_layer(
+                0, source_layer, None, fill=default_color, stroke=stroke_color, **common
+            )
+        )
     else:
-        circle_color = default_color
+        codes = categories if categories is not None else list(class_colors)
+        for idx, code in enumerate(codes):
+            layers.append(
+                _circle_layer(
+                    idx,
+                    source_layer,
+                    ["==", color_field, int(code)],
+                    fill=class_colors.get(code, default_color),
+                    stroke=stroke_color,
+                    **common,
+                )
+            )
 
     return {
         "version": 8,
         "sources": {
             "pmtiles_source": {"type": "vector", "url": f"pmtiles://{pmtiles_url}"}
         },
-        "layers": [
-            {
-                "id": "sample-points-circle",
-                "type": "circle",
-                "source": "pmtiles_source",
-                "source-layer": source_layer,
-                "paint": {
-                    "circle-radius": radius,
-                    "circle-color": circle_color,
-                    "circle-stroke-color": stroke_color,
-                    "circle-stroke-width": stroke_width,
-                    "circle-opacity": opacity,
-                },
-            }
-        ],
+        "layers": layers,
     }
 
 
@@ -117,45 +164,72 @@ POINT_CONVERSION_OPTIONS = {
 }
 
 
-def _default_layer_factory(source, *, style, conversion_options, allowed_directories):
+async def _default_layer_factory(
+    source, *, style, conversion_options, allowed_directories
+):
     """The ONE seam where the tile-library is imported.
 
     ``vectortileserver`` (PyPI) is the only external tile dependency; nothing
     else in the codebase references it. A per-build ``TileWorkspace`` carries the
     temp ``dest_dir`` as an allowed directory so the shared tile server can serve
-    it. ``.open`` runs tippecanoe synchronously on the calling (worker) thread and
-    returns a layer that already knows its own ``.bounds``.
+    it. ``open_async`` offloads tippecanoe to a thread and builds the layer widget
+    on the event loop, returning a layer that already knows its own ``.bounds``.
     """
     import vectortileserver as vts
 
     workspace = vts.TileWorkspace(allowed_directories=allowed_directories)
-    return workspace.open(source, style=style, conversion_options=conversion_options)
+    return await workspace.open_async(
+        source, style=style, conversion_options=conversion_options
+    )
 
 
-def build_points_pmtiles_layer(
+def _point_categories(df: pd.DataFrame, color_field: str):
+    """Distinct ``color_field`` values present in ``df``, one flat layer each.
+
+    Coerced to ``int`` because protomaps-leaflet's ``==`` filter is strict
+    equality against the numeric tile properties. ``None`` when the field is
+    absent (nothing to categorize -> a single flat layer).
+    """
+    if color_field in df.columns:
+        return sorted(int(v) for v in df[color_field].dropna().unique())
+    return None
+
+
+async def build_points_pmtiles_layer(
     df: pd.DataFrame,
     class_colors: dict,
     *,
     dest_dir: str,
     color_field: str = "map_code",
     default_color: str = "#888888",
+    stroke_color: str = POINT_HALO_COLOR,
     layer_factory: Optional[Callable] = None,
+    radius: int = 5,
+    stroke_width: int = 1,
 ):
     """Convert points to PMTiles and return an ipyleaflet layer.
 
     Writes the GeoJSON into ``dest_dir``, opens it through ``vectortileserver``
-    (tippecanoe, with point-retention options) with a categorized ``circle``
-    style, and returns the layer -- which carries its own ``.bounds`` for
-    auto-zoom. Raises :class:`VectorTileError` on any failure (missing library,
-    tippecanoe error, no vector layers produced).
+    (tippecanoe, with point-retention options) with a per-class ``circle`` style,
+    and returns the layer -- which carries its own ``.bounds`` for auto-zoom.
+    Awaitable: the geojson write and the conversion both run off the event loop.
+    Raises :class:`VectorTileError` on any failure (missing library, tippecanoe
+    error, no vector layers produced). ``color_field`` rides along as a
+    tile-feature property so its per-class filters match.
     """
     if layer_factory is None:
         layer_factory = _default_layer_factory
 
     geojson_path = os.path.join(dest_dir, "sample_points.geojson")
-    try:
+    props = (color_field,)
+    categories = _point_categories(df, color_field)
+
+    def _write_geojson():
         with open(geojson_path, "w") as fh:
-            json.dump(points_to_geojson(df, props=(color_field,)), fh)
+            json.dump(points_to_geojson(df, props=props), fh)
+
+    try:
+        await asyncio.to_thread(_write_geojson)
     except (OSError, TypeError) as e:
         raise VectorTileError(f"Could not write points GeoJSON: {e}") from e
 
@@ -171,10 +245,14 @@ def build_points_pmtiles_layer(
             vector_layers[0]["id"],
             color_field=color_field,
             default_color=default_color,
+            stroke_color=stroke_color,
+            radius=radius,
+            stroke_width=stroke_width,
+            categories=categories,
         )
 
     try:
-        layer = layer_factory(
+        layer = await layer_factory(
             geojson_path,
             style=style_from,
             conversion_options=POINT_CONVERSION_OPTIONS,
@@ -190,19 +268,23 @@ def build_points_pmtiles_layer(
         raise VectorTileError(f"Could not build PMTiles point layer: {e}") from e
 
 
-def build_layer_or_notify(sbae_map, points_df, class_colors):
-    """Build the sample-points layer, notifying (not raising) on failure.
+async def build_layer_or_notify(sbae_map, points_df):
+    """Build the design sample-points layer, notifying (not raising) on failure.
 
     Returns the layer, or ``None`` when there is no map, no points, or the build
-    failed (an error is surfaced via ``app_state.add_error``). Safe to call from
-    a worker thread; the caller attaches the returned layer on the main thread.
+    failed (an error is surfaced via ``app_state.add_error``). Awaitable; the
+    caller attaches the returned layer on the event loop. Design points are a
+    single neutral colour (see ``SAMPLE_POINT_COLOR``) -- per-class colouring
+    only fights the classification map underneath.
     """
     if sbae_map is None or points_df is None or points_df.empty:
         return None
     from component.model import app_state
 
     try:
-        return sbae_map.build_sample_points_layer(points_df, class_colors)
+        return await sbae_map.build_sample_points_layer(
+            points_df, point_color=SAMPLE_POINT_COLOR
+        )
     except Exception as e:
         # Intentionally broad: this is a non-essential map-layer build, called
         # from the point-generation worker thread. Any failure here -- not just

--- a/component/scripts/vector_tiles.py
+++ b/component/scripts/vector_tiles.py
@@ -117,15 +117,19 @@ POINT_CONVERSION_OPTIONS = {
 }
 
 
-def _default_client_factory(**kwargs):
+def _default_layer_factory(source, *, style, conversion_options, allowed_directories):
     """The ONE seam where the tile-library is imported.
 
     ``vectortileserver`` (PyPI) is the only external tile dependency; nothing
-    else in the codebase references it.
+    else in the codebase references it. A per-build ``TileWorkspace`` carries the
+    temp ``dest_dir`` as an allowed directory so the shared tile server can serve
+    it. ``.open`` runs tippecanoe synchronously on the calling (worker) thread and
+    returns a layer that already knows its own ``.bounds``.
     """
-    from vectortileserver.client import TileClient
+    import vectortileserver as vts
 
-    return TileClient(**kwargs)
+    workspace = vts.TileWorkspace(allowed_directories=allowed_directories)
+    return workspace.open(source, style=style, conversion_options=conversion_options)
 
 
 def build_points_pmtiles_layer(
@@ -135,17 +139,18 @@ def build_points_pmtiles_layer(
     dest_dir: str,
     color_field: str = "map_code",
     default_color: str = "#888888",
-    client_factory: Optional[Callable] = None,
+    layer_factory: Optional[Callable] = None,
 ):
     """Convert points to PMTiles and return an ipyleaflet layer.
 
-    Writes the GeoJSON into ``dest_dir``, runs the tile client (tippecanoe) with
-    point-retention options, builds the circle style, and returns the leaflet
-    layer. Raises :class:`VectorTileError` on any failure (missing library,
+    Writes the GeoJSON into ``dest_dir``, opens it through ``vectortileserver``
+    (tippecanoe, with point-retention options) with a categorized ``circle``
+    style, and returns the layer -- which carries its own ``.bounds`` for
+    auto-zoom. Raises :class:`VectorTileError` on any failure (missing library,
     tippecanoe error, no vector layers produced).
     """
-    if client_factory is None:
-        client_factory = _default_client_factory
+    if layer_factory is None:
+        layer_factory = _default_layer_factory
 
     geojson_path = os.path.join(dest_dir, "sample_points.geojson")
     try:
@@ -154,26 +159,31 @@ def build_points_pmtiles_layer(
     except (OSError, TypeError) as e:
         raise VectorTileError(f"Could not write points GeoJSON: {e}") from e
 
+    def style_from(metadata, pmtiles_url):
+        # A style *builder*: the circle style needs the tile URL and the archive's
+        # own vector-layer id, neither known until the archive has been built.
+        vector_layers = metadata.get("vector_layers", [])
+        if not vector_layers:
+            raise VectorTileError("Tile conversion produced no vector layers.")
+        return build_point_style(
+            pmtiles_url,
+            class_colors,
+            vector_layers[0]["id"],
+            color_field=color_field,
+            default_color=default_color,
+        )
+
     try:
-        client = client_factory(
-            data_source=geojson_path,
+        layer = layer_factory(
+            geojson_path,
+            style=style_from,
             conversion_options=POINT_CONVERSION_OPTIONS,
             allowed_directories=[dest_dir],
         )
         # The tile server just booted its uvicorn (and vectortileserver's DEBUG
         # logger); pin their levels down now so it sticks past uvicorn's config.
         quiet_tile_server_logs()
-        layers = client.list_layers()
-        if not layers:
-            raise VectorTileError("Tile conversion produced no vector layers.")
-        style = build_point_style(
-            client.pmtiles_url,
-            class_colors,
-            layers[0],
-            color_field=color_field,
-            default_color=default_color,
-        )
-        return client.create_leaflet_layer(style=style)
+        return layer
     except VectorTileError:
         raise
     except Exception as e:

--- a/component/scripts/vector_tiles.py
+++ b/component/scripts/vector_tiles.py
@@ -43,3 +43,52 @@ def points_to_geojson(
             }
         )
     return {"type": "FeatureCollection", "features": features}
+
+
+def build_point_style(
+    pmtiles_url: str,
+    class_colors: dict,
+    source_layer: str,
+    *,
+    color_field: str = "map_code",
+    default_color: str = "#888888",
+    radius: int = 5,
+    stroke_color: str = "#ffffff",
+    stroke_width: int = 1,
+    opacity: float = 0.85,
+) -> dict:
+    """Build a MapLibre style with one categorized ``circle`` layer.
+
+    ``circle-color`` is a ``["match", ["get", color_field], code, hex, ...,
+    default]`` expression from ``class_colors``. Empty ``class_colors`` yields a
+    plain ``default_color`` (no match expression).
+    """
+    if class_colors:
+        circle_color = ["match", ["get", color_field]]
+        for code, hex_color in class_colors.items():
+            circle_color.extend([int(code), hex_color])
+        circle_color.append(default_color)
+    else:
+        circle_color = default_color
+
+    return {
+        "version": 8,
+        "sources": {
+            "pmtiles_source": {"type": "vector", "url": f"pmtiles://{pmtiles_url}"}
+        },
+        "layers": [
+            {
+                "id": "sample-points-circle",
+                "type": "circle",
+                "source": "pmtiles_source",
+                "source-layer": source_layer,
+                "paint": {
+                    "circle-radius": radius,
+                    "circle-color": circle_color,
+                    "circle-stroke-color": stroke_color,
+                    "circle-stroke-width": stroke_width,
+                    "circle-opacity": opacity,
+                },
+            }
+        ],
+    }

--- a/component/scripts/vector_tiles.py
+++ b/component/scripts/vector_tiles.py
@@ -134,6 +134,7 @@ def build_points_pmtiles_layer(
     *,
     dest_dir: str,
     color_field: str = "map_code",
+    default_color: str = "#888888",
     client_factory: Optional[Callable] = None,
 ):
     """Convert points to PMTiles and return an ipyleaflet layer.
@@ -166,7 +167,11 @@ def build_points_pmtiles_layer(
         if not layers:
             raise VectorTileError("Tile conversion produced no vector layers.")
         style = build_point_style(
-            client.pmtiles_url, class_colors, layers[0], color_field=color_field
+            client.pmtiles_url,
+            class_colors,
+            layers[0],
+            color_field=color_field,
+            default_color=default_color,
         )
         return client.create_leaflet_layer(style=style)
     except VectorTileError:

--- a/component/scripts/vector_tiles.py
+++ b/component/scripts/vector_tiles.py
@@ -1,0 +1,45 @@
+"""Render sample points as a PMTiles vector-tile layer.
+
+DataFrame -> GeoJSON, the MapLibre circle style, and the call into the tile
+library all live here so they stay pure and unit-testable. The tile-library
+import is confined to ``_default_client_factory`` -- the ONE seam where the
+(not-yet-published) package name appears.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def points_to_geojson(
+    df: pd.DataFrame,
+    x_col: str = "longitude",
+    y_col: str = "latitude",
+    props: tuple[str, ...] = ("map_code",),
+) -> dict:
+    """Build a GeoJSON FeatureCollection of points from a DataFrame.
+
+    Coordinates are written ``[lon, lat]`` (GeoJSON order). Only the columns in
+    ``props`` that are present in ``df`` are copied onto each feature; NaN
+    values are skipped. ``map_code`` is coerced to ``int`` for clean JSON.
+    """
+    present = [p for p in props if p in df.columns]
+    features = []
+    for _, row in df.iterrows():
+        properties = {}
+        for p in present:
+            value = row[p]
+            if pd.isna(value):
+                continue
+            properties[p] = int(value) if p == "map_code" else value
+        features.append(
+            {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [float(row[x_col]), float(row[y_col])],
+                },
+                "properties": properties,
+            }
+        )
+    return {"type": "FeatureCollection", "features": features}

--- a/component/scripts/vector_tiles.py
+++ b/component/scripts/vector_tiles.py
@@ -9,10 +9,13 @@ import is confined to ``_default_client_factory`` -- the ONE seam where the
 from __future__ import annotations
 
 import json
+import logging
 import os
 from typing import Callable, Optional
 
 import pandas as pd
+
+logger = logging.getLogger("sbae.vector_tiles")
 
 
 def points_to_geojson(
@@ -118,7 +121,7 @@ def _default_client_factory(**kwargs):
     When the package is published, update this import to the real name; nothing
     else in the codebase references the library.
     """
-    from pyvectortiles.client import TileClient  # noqa: PLC0415
+    from pyvectortiles.client import TileClient
 
     return TileClient(**kwargs)
 
@@ -188,5 +191,6 @@ def build_layer_or_notify(sbae_map, points_df, class_colors):
         # points back to the app (see build_sample_points_layer's mkdtemp call,
         # which can raise a raw OSError outside build_points_pmtiles_layer's
         # own try/except).
+        logger.warning("Sample points layer failed: %s", e)
         app_state.add_error(f"Could not render sample points on the map: {e}")
         return None

--- a/component/scripts/vector_tiles.py
+++ b/component/scripts/vector_tiles.py
@@ -145,7 +145,7 @@ def build_points_pmtiles_layer(
     try:
         with open(geojson_path, "w") as fh:
             json.dump(points_to_geojson(df, props=(color_field,)), fh)
-    except OSError as e:
+    except (OSError, TypeError) as e:
         raise VectorTileError(f"Could not write points GeoJSON: {e}") from e
 
     try:

--- a/component/scripts/vector_tiles.py
+++ b/component/scripts/vector_tiles.py
@@ -165,3 +165,21 @@ def build_points_pmtiles_layer(
         raise
     except Exception as e:
         raise VectorTileError(f"Could not build PMTiles point layer: {e}") from e
+
+
+def build_layer_or_notify(sbae_map, points_df, class_colors):
+    """Build the sample-points layer, notifying (not raising) on failure.
+
+    Returns the layer, or ``None`` when there is no map, no points, or the build
+    failed (an error is surfaced via ``app_state.add_error``). Safe to call from
+    a worker thread; the caller attaches the returned layer on the main thread.
+    """
+    if sbae_map is None or points_df is None or points_df.empty:
+        return None
+    from component.model import app_state
+
+    try:
+        return sbae_map.build_sample_points_layer(points_df, class_colors)
+    except VectorTileError as e:
+        app_state.add_error(f"Could not render sample points on the map: {e}")
+        return None

--- a/component/scripts/vector_tiles.py
+++ b/component/scripts/vector_tiles.py
@@ -8,6 +8,10 @@ import is confined to ``_default_client_factory`` -- the ONE seam where the
 
 from __future__ import annotations
 
+import json
+import os
+from typing import Callable, Optional
+
 import pandas as pd
 
 
@@ -92,3 +96,72 @@ def build_point_style(
             }
         ],
     }
+
+
+class VectorTileError(Exception):
+    """Raised when a PMTiles point layer cannot be built."""
+
+
+# tippecanoe options that keep 100% of point features at every zoom. Accuracy
+# assessment cannot silently drop points, so dot-dropping and the tile/feature
+# limits are disabled. See the ipy-pmtiles contract, requirement R2.
+POINT_CONVERSION_OPTIONS = {
+    "drop_rate": 1,  # -r1: no dot-dropping below maxzoom
+    "no_feature_limit": True,  # -pf
+    "no_tile_size_limit": True,  # -pk
+}
+
+
+def _default_client_factory(**kwargs):
+    """The ONE seam where the tile-library name appears.
+
+    When the package is published, update this import to the real name; nothing
+    else in the codebase references the library.
+    """
+    from pyvectortiles.client import TileClient  # noqa: PLC0415
+
+    return TileClient(**kwargs)
+
+
+def build_points_pmtiles_layer(
+    df: pd.DataFrame,
+    class_colors: dict,
+    *,
+    dest_dir: str,
+    color_field: str = "map_code",
+    client_factory: Optional[Callable] = None,
+):
+    """Convert points to PMTiles and return an ipyleaflet layer.
+
+    Writes the GeoJSON into ``dest_dir``, runs the tile client (tippecanoe) with
+    point-retention options, builds the circle style, and returns the leaflet
+    layer. Raises :class:`VectorTileError` on any failure (missing library,
+    tippecanoe error, no vector layers produced).
+    """
+    if client_factory is None:
+        client_factory = _default_client_factory
+
+    geojson_path = os.path.join(dest_dir, "sample_points.geojson")
+    try:
+        with open(geojson_path, "w") as fh:
+            json.dump(points_to_geojson(df, props=(color_field,)), fh)
+    except OSError as e:
+        raise VectorTileError(f"Could not write points GeoJSON: {e}") from e
+
+    try:
+        client = client_factory(
+            data_source=geojson_path,
+            conversion_options=POINT_CONVERSION_OPTIONS,
+            allowed_directories=[dest_dir],
+        )
+        layers = client.list_layers()
+        if not layers:
+            raise VectorTileError("Tile conversion produced no vector layers.")
+        style = build_point_style(
+            client.pmtiles_url, class_colors, layers[0], color_field=color_field
+        )
+        return client.create_leaflet_layer(style=style)
+    except VectorTileError:
+        raise
+    except Exception as e:
+        raise VectorTileError(f"Could not build PMTiles point layer: {e}") from e

--- a/component/scripts/vector_tiles.py
+++ b/component/scripts/vector_tiles.py
@@ -2,8 +2,8 @@
 
 DataFrame -> GeoJSON, the MapLibre circle style, and the call into the tile
 library all live here so they stay pure and unit-testable. The tile-library
-import is confined to ``_default_client_factory`` -- the ONE seam where the
-(not-yet-published) package name appears.
+import is confined to ``_default_client_factory`` -- the ONE seam that touches
+``vectortileserver``.
 """
 
 from __future__ import annotations
@@ -116,12 +116,12 @@ POINT_CONVERSION_OPTIONS = {
 
 
 def _default_client_factory(**kwargs):
-    """The ONE seam where the tile-library name appears.
+    """The ONE seam where the tile-library is imported.
 
-    When the package is published, update this import to the real name; nothing
-    else in the codebase references the library.
+    ``vectortileserver`` (PyPI) is the only external tile dependency; nothing
+    else in the codebase references it.
     """
-    from pyvectortiles.client import TileClient
+    from vectortileserver.client import TileClient
 
     return TileClient(**kwargs)
 

--- a/component/scripts/vector_tiles.py
+++ b/component/scripts/vector_tiles.py
@@ -180,6 +180,13 @@ def build_layer_or_notify(sbae_map, points_df, class_colors):
 
     try:
         return sbae_map.build_sample_points_layer(points_df, class_colors)
-    except VectorTileError as e:
+    except Exception as e:
+        # Intentionally broad: this is a non-essential map-layer build, called
+        # from the point-generation worker thread. Any failure here -- not just
+        # VectorTileError -- must be swallowed and reported, never raised, or
+        # the worker thread dies before it can hand the already-generated
+        # points back to the app (see build_sample_points_layer's mkdtemp call,
+        # which can raise a raw OSError outside build_points_pmtiles_layer's
+        # own try/except).
         app_state.add_error(f"Could not render sample points on the map: {e}")
         return None

--- a/component/scripts/vector_tiles.py
+++ b/component/scripts/vector_tiles.py
@@ -15,6 +15,8 @@ from typing import Callable, Optional
 
 import pandas as pd
 
+from component.scripts.logging_config import quiet_tile_server_logs
+
 logger = logging.getLogger("sbae.vector_tiles")
 
 
@@ -157,6 +159,9 @@ def build_points_pmtiles_layer(
             conversion_options=POINT_CONVERSION_OPTIONS,
             allowed_directories=[dest_dir],
         )
+        # The tile server just booted its uvicorn (and vectortileserver's DEBUG
+        # logger); pin their levels down now so it sticks past uvicorn's config.
+        quiet_tile_server_logs()
         layers = client.list_layers()
         if not layers:
             raise VectorTileError("Tile conversion produced no vector layers.")

--- a/component/tile/class_editor.py
+++ b/component/tile/class_editor.py
@@ -189,7 +189,6 @@ def class_editor_table(show_sample_controls=True):
                         ):
                             solara.Text(
                                 f"{eua_value:.0f}%",
-                                classes=["text--secondary"],
                                 style="font-size: 0.9em; line-height: 2.5;",
                             )
 
@@ -198,7 +197,6 @@ def class_editor_table(show_sample_controls=True):
                     ):
                         solara.Text(
                             f"{area_ha:,.2f} ha ({area_pct:.1f}%)",
-                            classes=["text--secondary"],
                             style="font-size: 0.9em;",
                         )
                         solara.HTML(

--- a/component/tile/upload.py
+++ b/component/tile/upload.py
@@ -98,7 +98,6 @@ def CurrentFileDisplay(sbae_map: SbaeMap = None):
                 solara.HTML(
                     tag="div",
                     unsafe_innerHTML=f"Type: {file_type} | Size: {size_mb:.1f} MB",
-                    classes=["text--secondary"],
                     style="font-size: 12px; margin-top: 4px;",
                 )
 
@@ -491,7 +490,5 @@ def FilePreview(file_info: Dict[str, Any]):
         solara.Text("File selected", style="font-weight: 600; margin-bottom: 4px;")
         for label, value in rows:
             with solara.Row(gap="8px"):
-                solara.Text(
-                    f"{label}:", classes=["text--secondary"], style="min-width: 72px;"
-                )
+                solara.Text(f"{label}:", style="min-width: 72px;")
                 solara.Text(str(value))

--- a/component/widget/analysis_chart.py
+++ b/component/widget/analysis_chart.py
@@ -2,7 +2,7 @@
 
 import solara
 from ipecharts.option import Grid, Legend, Option, Title, Tooltip, XAxis, YAxis
-from ipecharts.option.series import Bar, Custom
+from ipecharts.option.series import Bar, Custom, Pie
 from ipecharts.tools import encode_js_fn
 
 from component.model import app_state
@@ -180,6 +180,61 @@ def AccuracyByClassChart(results: dict, theme_toggle=None):
         yAxis=YAxis(type="value", name="%", max=100),
         grid=Grid(left="10%", right="6%", top="14%", bottom="18%"),
         series=[Bar(name="User's", data=users), Bar(name="Producer's", data=producers)],
+    )
+    EChartsWidget.element(
+        option=option,
+        style={"height": "420px", "width": "100%"},
+        theme_toggle=theme_toggle,
+    )
+
+
+_PIE_FALLBACK = [
+    "#5470c6",
+    "#91cc75",
+    "#fac858",
+    "#ee6666",
+    "#73c0de",
+    "#3ba272",
+    "#fc8452",
+    "#9a60b4",
+    "#ea7ccc",
+]
+
+
+@solara.component
+def AreaProportionChart(results: dict, theme_toggle=None):
+    rows = results.get("class_estimates", [])
+    if not rows:
+        return
+    colors = app_state.class_colors.value or {}
+    total = sum(max(r["area_estimate"], 0.0) for r in rows) or 1.0
+    pie_data = []
+    chart_colors = []
+    for idx, r in enumerate(rows):
+        pct = 100.0 * max(r["area_estimate"], 0.0) / total
+        chart_colors.append(
+            colors.get(r["map_code"], _PIE_FALLBACK[idx % len(_PIE_FALLBACK)])
+        )
+        pie_data.append(
+            {"value": round(pct, 2), "name": f"{r['class_name']} ({pct:.1f}%)"}
+        )
+    pie = Pie(
+        data=pie_data,
+        radius=[50, 100],
+        itemStyle={"borderRadius": 5, "borderColor": "#fff", "borderWidth": 2},
+        label={"show": False, "position": "center"},
+        emphasis={"label": {"show": True, "fontSize": 12}},
+    )
+    option = Option(
+        backgroundColor="#1e1e1e00",
+        legend=Legend(bottom=0),
+        series=[pie],
+        color=chart_colors,
+        title=Title(
+            text="Estimated area proportion",
+            left="center",
+            textStyle={"fontSize": 13, "fontWeight": "normal"},
+        ),
     )
     EChartsWidget.element(
         option=option,

--- a/component/widget/analysis_chart.py
+++ b/component/widget/analysis_chart.py
@@ -1,7 +1,7 @@
 """Bar chart of error-adjusted area per class, with confidence-interval bars."""
 
 import solara
-from ipecharts.option import Grid, Option, Title, Tooltip, XAxis, YAxis
+from ipecharts.option import Grid, Legend, Option, Title, Tooltip, XAxis, YAxis
 from ipecharts.option.series import Bar, Custom
 from ipecharts.tools import encode_js_fn
 
@@ -149,6 +149,39 @@ def ConfusionMatrixChart(results: dict, theme_toggle=None):
         ],
     }
     RawEChartsWidget.element(
+        option=option,
+        style={"height": "420px", "width": "100%"},
+        theme_toggle=theme_toggle,
+    )
+
+
+@solara.component
+def AccuracyByClassChart(results: dict, theme_toggle=None):
+    rows = results.get("accuracy_rows", [])
+    if not rows:
+        return
+    names = [r["class_name"] for r in rows]
+    users = [round(r["users_accuracy"] * 100, 1) for r in rows]
+    producers = [round(r["producers_accuracy"] * 100, 1) for r in rows]
+    option = Option(
+        backgroundColor="#1e1e1e00",
+        title=Title(
+            text="Accuracy by class",
+            left="center",
+            textStyle={"fontSize": 13, "fontWeight": "normal"},
+        ),
+        tooltip=Tooltip(trigger="axis", axisPointer={"type": "shadow"}),
+        legend=Legend(bottom=0),
+        xAxis=XAxis(
+            type="category",
+            data=names,
+            axisLabel={"fontSize": 10, "interval": 0, "rotate": 30},
+        ),
+        yAxis=YAxis(type="value", name="%", max=100),
+        grid=Grid(left="10%", right="6%", top="14%", bottom="18%"),
+        series=[Bar(name="User's", data=users), Bar(name="Producer's", data=producers)],
+    )
+    EChartsWidget.element(
         option=option,
         style={"height": "420px", "width": "100%"},
         theme_toggle=theme_toggle,

--- a/component/widget/analysis_chart.py
+++ b/component/widget/analysis_chart.py
@@ -7,7 +7,7 @@ from ipecharts.tools import encode_js_fn
 
 from component.model import app_state
 from component.scripts.accuracy import convert_area
-from component.widget.echarts import EChartsWidget
+from component.widget.echarts import EChartsWidget, RawEChartsWidget
 
 
 @solara.component
@@ -68,6 +68,87 @@ def AreaEstimateChart(results: dict, unit: str, theme_toggle=None):
     )
     # Card-less: the chart carries its own title, and the right panel avoids cards.
     EChartsWidget.element(
+        option=option,
+        style={"height": "420px", "width": "100%"},
+        theme_toggle=theme_toggle,
+    )
+
+
+def confusion_heatmap_data(confusion_matrix: dict):
+    """Reshape a confusion-matrix dict into echarts heatmap inputs.
+
+    Returns (x_labels, y_labels, triples, max_count):
+      x_labels = reference classes (columns) as strings
+      y_labels = mapped classes (index) as strings
+      triples  = [x_index, y_index, count] for every cell
+      max_count = largest cell value, at least 1 (for visualMap.max)
+    """
+    x_labels = [str(c) for c in confusion_matrix.get("columns", [])]
+    y_labels = [str(i) for i in confusion_matrix.get("index", [])]
+    triples = []
+    max_count = 0.0
+    for y, row in enumerate(confusion_matrix.get("data", [])):
+        for x, value in enumerate(row):
+            count = float(value)
+            triples.append([x, y, count])
+            max_count = max(max_count, count)
+    return x_labels, y_labels, triples, max(max_count, 1.0)
+
+
+@solara.component
+def ConfusionMatrixChart(results: dict, theme_toggle=None):
+    cm = results.get("confusion_matrix")
+    if not cm:
+        return
+    x_labels, y_labels, triples, max_count = confusion_heatmap_data(cm)
+    option = {
+        "backgroundColor": "#1e1e1e00",
+        "title": {
+            "text": "Confusion matrix (map -> reference)",
+            "left": "center",
+            "textStyle": {"fontSize": 13, "fontWeight": "normal"},
+        },
+        "tooltip": {"position": "top"},
+        "grid": {"top": "14%", "bottom": "18%", "left": "16%", "right": "8%"},
+        "xAxis": {
+            "type": "category",
+            "data": x_labels,
+            "name": "reference",
+            "nameLocation": "middle",
+            "nameGap": 28,
+            "splitArea": {"show": True},
+            "axisLabel": {"fontSize": 10},
+        },
+        "yAxis": {
+            "type": "category",
+            "data": y_labels,
+            "name": "map",
+            "splitArea": {"show": True},
+            "axisLabel": {"fontSize": 10},
+        },
+        "visualMap": {
+            "min": 0,
+            "max": max_count,
+            "calculable": True,
+            "orient": "horizontal",
+            "left": "center",
+            "bottom": "2%",
+        },
+        "series": [
+            {
+                "type": "heatmap",
+                "data": triples,
+                "label": {"show": True, "fontSize": 9},
+                "emphasis": {
+                    "itemStyle": {
+                        "shadowBlur": 6,
+                        "shadowColor": "rgba(0,0,0,0.3)",
+                    }
+                },
+            }
+        ],
+    }
+    RawEChartsWidget.element(
         option=option,
         style={"height": "420px", "width": "100%"},
         theme_toggle=theme_toggle,

--- a/component/widget/analysis_chart.py
+++ b/component/widget/analysis_chart.py
@@ -2,16 +2,36 @@
 
 Error-adjusted area bars, confusion-matrix heatmap, accuracy-by-class bars,
 and estimated-area proportion pie.
+
+Each chart is rendered title-less and wrapped in a ``solara.Card`` whose header
+(a centered caption) carries the title. Colors baked into the option (error-bar
+stroke, slice gaps) must be theme-neutral: the option is built once and is NOT
+rebuilt on a theme toggle (only the echarts ``theme`` trait live-updates), so a
+value derived from the active theme at build time would go stale the moment the
+user switches themes.
 """
 
 import solara
-from ipecharts.option import Grid, Legend, Option, Title, Tooltip, XAxis, YAxis
+from ipecharts.option import Grid, Legend, Option, Tooltip, XAxis, YAxis
 from ipecharts.option.series import Bar, Custom, Pie
 from ipecharts.tools import encode_js_fn
 
 from component.model import app_state
 from component.scripts.accuracy import convert_area
 from component.widget.echarts import EChartsWidget, RawEChartsWidget
+
+# Uniform chart height inside the dashboard cards.
+_CHART_H = "340px"
+# Mid-gray that stays visible on both light and dark chart surfaces (the option
+# is not rebuilt on theme toggle, so this must not depend on the active theme).
+_NEUTRAL_STROKE = "#888888"
+
+
+@solara.component
+def _ChartTitle(title: str):
+    """Centered card header used in place of the (removed) in-chart title."""
+    with solara.Row(justify="center", style="padding-bottom: 4px;"):
+        solara.Text(title, classes=["text-subtitle-1", "font-weight-medium"])
 
 
 @solara.component
@@ -45,7 +65,7 @@ def AreaEstimateChart(results: dict, unit: str, theme_toggle=None):
                 "var lo = api.coord([api.value(1), cat]);"
                 "var hi = api.coord([api.value(2), cat]);"
                 "var h = 6;"
-                "var style = {stroke: '#333', lineWidth: 1.5};"
+                f"var style = {{stroke: '{_NEUTRAL_STROKE}', lineWidth: 1.5}};"
                 "return {type:'group', children:["
                 "  {type:'line', shape:{x1:lo[0],y1:lo[1],x2:hi[0],y2:hi[1]}, style:style},"
                 "  {type:'line', shape:{x1:lo[0],y1:lo[1]-h,x2:lo[0],y2:lo[1]+h}, style:style},"
@@ -58,25 +78,21 @@ def AreaEstimateChart(results: dict, unit: str, theme_toggle=None):
 
     option = Option(
         backgroundColor="#1e1e1e00",
-        title=Title(
-            text="Error-adjusted area by class",
-            left="center",
-            textStyle={"fontSize": 13, "fontWeight": "normal"},
-        ),
         xAxis=XAxis(
             type="value", name=f"Area ({u})", nameLocation="middle", nameGap=28
         ),
         yAxis=YAxis(type="category", data=names, axisLabel={"fontSize": 10}),
         series=[bar, error_series],
         tooltip=Tooltip(trigger="axis", axisPointer={"type": "shadow"}),
-        grid=Grid(left="22%", right="8%", top="14%", bottom="12%"),
+        grid=Grid(left="22%", right="8%", top="8%", bottom="16%"),
     )
-    # Card-less: the chart carries its own title, and the right panel avoids cards.
-    EChartsWidget.element(
-        option=option,
-        style={"height": "420px", "width": "100%"},
-        theme_toggle=theme_toggle,
-    )
+    with solara.Card(margin=0):
+        _ChartTitle(f"Error-adjusted area by class ({u})")
+        EChartsWidget.element(
+            option=option,
+            style={"height": _CHART_H, "width": "100%"},
+            theme_toggle=theme_toggle,
+        )
 
 
 def confusion_heatmap_data(confusion_matrix: dict):
@@ -108,19 +124,16 @@ def ConfusionMatrixChart(results: dict, theme_toggle=None):
     x_labels, y_labels, triples, max_count = confusion_heatmap_data(cm)
     option = {
         "backgroundColor": "#1e1e1e00",
-        "title": {
-            "text": "Confusion matrix (map -> reference)",
-            "left": "center",
-            "textStyle": {"fontSize": 13, "fontWeight": "normal"},
-        },
         "tooltip": {"position": "top"},
-        "grid": {"top": "14%", "bottom": "18%", "left": "16%", "right": "8%"},
+        # Extra bottom room so the color scale sits clearly below the x-axis
+        # label instead of crowding it.
+        "grid": {"top": "8%", "bottom": "24%", "left": "16%", "right": "8%"},
         "xAxis": {
             "type": "category",
             "data": x_labels,
             "name": "reference",
             "nameLocation": "middle",
-            "nameGap": 28,
+            "nameGap": 26,
             "splitArea": {"show": True},
             "axisLabel": {"fontSize": 10},
         },
@@ -138,6 +151,9 @@ def ConfusionMatrixChart(results: dict, theme_toggle=None):
             "orient": "horizontal",
             "left": "center",
             "bottom": "2%",
+            # For a horizontal bar, itemHeight is the *length*; keep it wide.
+            "itemWidth": 14,
+            "itemHeight": 160,
         },
         "series": [
             {
@@ -153,11 +169,13 @@ def ConfusionMatrixChart(results: dict, theme_toggle=None):
             }
         ],
     }
-    RawEChartsWidget.element(
-        option=option,
-        style={"height": "420px", "width": "100%"},
-        theme_toggle=theme_toggle,
-    )
+    with solara.Card(margin=0):
+        _ChartTitle("Confusion matrix (map → reference)")
+        RawEChartsWidget.element(
+            option=option,
+            style={"height": _CHART_H, "width": "100%"},
+            theme_toggle=theme_toggle,
+        )
 
 
 @solara.component
@@ -170,27 +188,24 @@ def AccuracyByClassChart(results: dict, theme_toggle=None):
     producers = [round(r["producers_accuracy"] * 100, 1) for r in rows]
     option = Option(
         backgroundColor="#1e1e1e00",
-        title=Title(
-            text="Accuracy by class",
-            left="center",
-            textStyle={"fontSize": 13, "fontWeight": "normal"},
-        ),
         tooltip=Tooltip(trigger="axis", axisPointer={"type": "shadow"}),
-        legend=Legend(bottom=0),
+        legend=Legend(bottom=0, textStyle={"fontSize": 11}),
         xAxis=XAxis(
             type="category",
             data=names,
             axisLabel={"fontSize": 10, "interval": 0, "rotate": 30},
         ),
         yAxis=YAxis(type="value", name="%", max=100),
-        grid=Grid(left="10%", right="6%", top="14%", bottom="18%"),
+        grid=Grid(left="10%", right="6%", top="8%", bottom="20%"),
         series=[Bar(name="User's", data=users), Bar(name="Producer's", data=producers)],
     )
-    EChartsWidget.element(
-        option=option,
-        style={"height": "420px", "width": "100%"},
-        theme_toggle=theme_toggle,
-    )
+    with solara.Card(margin=0):
+        _ChartTitle("Accuracy by class")
+        EChartsWidget.element(
+            option=option,
+            style={"height": _CHART_H, "width": "100%"},
+            theme_toggle=theme_toggle,
+        )
 
 
 _PIE_FALLBACK = [
@@ -207,7 +222,9 @@ _PIE_FALLBACK = [
 
 
 @solara.component
-def AreaProportionChart(results: dict, theme_toggle=None):
+def AreaProportionChart(
+    results: dict, theme_toggle=None, legend_width: int | None = 480
+):
     rows = results.get("class_estimates", [])
     if not rows:
         return
@@ -225,24 +242,38 @@ def AreaProportionChart(results: dict, theme_toggle=None):
         )
     pie = Pie(
         data=pie_data,
-        radius=[50, 100],
-        itemStyle={"borderRadius": 5, "borderColor": "#fff", "borderWidth": 2},
+        radius=["38%", "58%"],
+        center=["50%", "38%"],
+        # No slice border: a theme-fixed border color would go stale on toggle
+        # (black rings in light mode); distinct class colors separate slices.
+        itemStyle={"borderRadius": 4},
         label={"show": False, "position": "center"},
         emphasis={"label": {"show": True, "fontSize": 12}},
     )
+    # Fixed-width legend so it wraps to ~5-6 items per line regardless of the
+    # chart width (a percentage over-fills on a wide chart), kept centered. In a
+    # narrow host (the right panel) pass legend_width=None for natural wrapping.
+    legend_opts = {
+        "orient": "horizontal",
+        "bottom": 0,
+        "left": "center",
+        "itemWidth": 12,
+        "itemHeight": 12,
+        "itemGap": 8,
+        "textStyle": {"fontSize": 10},
+    }
+    if legend_width is not None:
+        legend_opts["width"] = legend_width
     option = Option(
         backgroundColor="#1e1e1e00",
-        legend=Legend(bottom=0),
+        legend=Legend(**legend_opts),
         series=[pie],
         color=chart_colors,
-        title=Title(
-            text="Estimated area proportion",
-            left="center",
-            textStyle={"fontSize": 13, "fontWeight": "normal"},
-        ),
     )
-    EChartsWidget.element(
-        option=option,
-        style={"height": "420px", "width": "100%"},
-        theme_toggle=theme_toggle,
-    )
+    with solara.Card(margin=0):
+        _ChartTitle("Estimated area proportion")
+        EChartsWidget.element(
+            option=option,
+            style={"height": _CHART_H, "width": "100%"},
+            theme_toggle=theme_toggle,
+        )

--- a/component/widget/analysis_chart.py
+++ b/component/widget/analysis_chart.py
@@ -103,7 +103,7 @@ def confusion_heatmap_data(confusion_matrix: dict):
 @solara.component
 def ConfusionMatrixChart(results: dict, theme_toggle=None):
     cm = results.get("confusion_matrix")
-    if not cm:
+    if not cm or not cm.get("data"):
         return
     x_labels, y_labels, triples, max_count = confusion_heatmap_data(cm)
     option = {

--- a/component/widget/analysis_chart.py
+++ b/component/widget/analysis_chart.py
@@ -53,6 +53,7 @@ def AreaEstimateChart(results: dict, unit: str, theme_toggle=None):
     )
 
     option = Option(
+        backgroundColor="#1e1e1e00",
         title=Title(
             text="Error-adjusted area by class",
             left="center",

--- a/component/widget/analysis_chart.py
+++ b/component/widget/analysis_chart.py
@@ -223,7 +223,7 @@ _PIE_FALLBACK = [
 
 @solara.component
 def AreaProportionChart(
-    results: dict, theme_toggle=None, legend_width: int | None = 480
+    results: dict, theme_toggle=None, legend_width: int | None = 480, card: bool = True
 ):
     rows = results.get("class_estimates", [])
     if not rows:
@@ -270,10 +270,18 @@ def AreaProportionChart(
         series=[pie],
         color=chart_colors,
     )
-    with solara.Card(margin=0):
+
+    def _body():
         _ChartTitle("Estimated area proportion")
         EChartsWidget.element(
             option=option,
             style={"height": _CHART_H, "width": "100%"},
             theme_toggle=theme_toggle,
         )
+
+    # ``card=False`` drops the surface so it sits flush in the right panel.
+    if card:
+        with solara.Card(margin=0):
+            _body()
+    else:
+        _body()

--- a/component/widget/analysis_chart.py
+++ b/component/widget/analysis_chart.py
@@ -1,4 +1,8 @@
-"""Bar chart of error-adjusted area per class, with confidence-interval bars."""
+"""Charts for the analysis results.
+
+Error-adjusted area bars, confusion-matrix heatmap, accuracy-by-class bars,
+and estimated-area proportion pie.
+"""
 
 import solara
 from ipecharts.option import Grid, Legend, Option, Title, Tooltip, XAxis, YAxis

--- a/component/widget/analysis_dashboard.py
+++ b/component/widget/analysis_dashboard.py
@@ -57,82 +57,59 @@ def dashboard_kpis(results: dict) -> dict:
     }
 
 
-# One-line methodology note under the KPI row; each KPI's own meaning now lives
-# in its tile's info tooltip.
-_METHODOLOGY_NOTE = (
-    "Error-adjusted area estimates and class accuracies from your reference "
-    "sample, following Olofsson et al. (2014)."
-)
-
-
 @solara.component
-def _KpiCard(label: str, value: str, hint: str):
-    """A single dashboard stat tile with a corner info button.
+def _KpiStat(icon: str, label: str, value: str, hint: str):
+    """One compact KPI: a primary icon, a faded label, and the value.
 
-    Prominent value + muted label, plus a top-right info button whose tooltip
-    (``hint``) explains the metric. A plain theme-aware ``solara.Card`` (no
-    custom background) so it reads as a normal surface in both light and dark;
-    ``flex: 1`` lets the four share one row, and ``position: relative`` anchors
-    the corner info button.
+    Mirrors the sepal-gee-bundle dashboard stat items (icon + caption label +
+    body value in a dense list item, no surrounding card). ``hint`` rides along
+    as a hover tooltip so each metric keeps its explanation without clutter.
     """
-    with solara.Card(
-        margin=0,
-        elevation=2,
-        style="flex: 1 1 0; min-width: 0; position: relative;",
-    ):
-        with solara.Column(gap="2px", style="align-items: center;"):
-            solara.Text(
-                value,
-                style="font-weight: 700; font-size: 22px; line-height: 1.15;",
-            )
-            solara.Text(
-                label,
-                classes=["caption"],
-                style="opacity: 0.7; line-height: 1.2; text-align: center;",
-            )
-        with solara.Column(
-            gap="0px", style="position: absolute; top: 2px; right: 2px;"
-        ):
-            with solara.Tooltip(hint):
-                solara.v.Btn(
-                    icon=True,
-                    x_small=True,
-                    style_="opacity: 0.5;",
-                    children=[
-                        solara.v.Icon(small=True, children=["mdi-information-outline"])
-                    ],
-                )
+    with solara.Tooltip(hint):
+        with solara.v.Col(cols="auto", class_="pa-0"):
+            with solara.v.ListItem(dense=True, class_="pa-0 pr-4"):
+                with solara.v.ListItemIcon(class_="mr-2 my-auto"):
+                    solara.v.Icon(small=True, color="primary", children=[icon])
+                with solara.v.ListItemContent(class_="py-1"):
+                    solara.v.ListItemTitle(
+                        class_="caption", style_="opacity: 0.6;", children=[label]
+                    )
+                    solara.v.ListItemSubtitle(class_="body-2", children=[value])
 
 
 @solara.component
 def _DashboardKpiCards(results: dict):
-    """Overall accuracy / confidence / samples / classes as stat tiles, one row."""
+    """Overall accuracy / confidence / samples / classes as compact stat items."""
     k = dashboard_kpis(results)
     items = [
         (
+            "mdi-target",
             "Overall accuracy",
             f"{k['overall_accuracy_pct']:.1f}%",
             "Share of reference points classified correctly.",
         ),
         (
+            "mdi-percent-outline",
             "Confidence level",
             f"{k['confidence_level']:.0f}%",
             "Probability that the ± intervals contain the true value.",
         ),
         (
+            "mdi-map-marker-multiple",
             "Reference samples",
             f"{k['n_samples']:,}",
             "Total reference points assessed.",
         ),
         (
+            "mdi-shape-outline",
             "Classes",
             f"{k['n_classes']}",
             "Number of map classes evaluated.",
         ),
     ]
-    with solara.Row(gap="12px", style="flex-wrap: nowrap; margin-bottom: 8px;"):
-        for label, value, hint in items:
-            _KpiCard(label, value, hint)
+    with solara.v.Row(dense=True, align="center", justify="center", class_="mb-3"):
+        for icon, label, value, hint in items:
+            _KpiStat(icon, label, value, hint)
 
 
 @solara.component
@@ -156,20 +133,13 @@ def AnalysisDashboardModal(open, theme_toggle=None):
     unit = app_state.analysis_area_unit.value
 
     with solara.v.Dialog(
-        v_model=open.value, on_v_model=open.set, max_width=1100, eager=True
+        v_model=open.value, on_v_model=open.set, max_width=1400, eager=True
     ):
         with solara.v.Card():
             solara.v.CardTitle(children=["Accuracy assessment results"])
             with solara.v.CardText(style="max-height: 80vh; overflow-y: auto;"):
                 solara.v.Html(tag="div", children=[resizer], style_="display: none;")
                 _DashboardKpiCards(results)
-                solara.Text(
-                    _METHODOLOGY_NOTE,
-                    style=(
-                        "display: block; text-align: center; opacity: 0.6; "
-                        "font-size: 12px; margin: 0 auto 16px; max-width: 640px;"
-                    ),
-                )
                 with solara.ColumnsResponsive(6, small=12):
                     ConfusionMatrixChart(results, theme_toggle=theme_toggle)
                     AccuracyByClassChart(results, theme_toggle=theme_toggle)
@@ -208,7 +178,9 @@ def AnalysisSummaryCard(theme_toggle=None):
                 solara.v.Chip(
                     small=True, label=True, outlined=True, children=[chip_text]
                 )
-        AreaProportionChart(results, theme_toggle=theme_toggle, legend_width=None)
+        AreaProportionChart(
+            results, theme_toggle=theme_toggle, legend_width=None, card=False
+        )
         solara.Button(
             "View dashboard",
             color="primary",

--- a/component/widget/analysis_dashboard.py
+++ b/component/widget/analysis_dashboard.py
@@ -57,23 +57,29 @@ def dashboard_kpis(results: dict) -> dict:
     }
 
 
-# Short (<= 3 lines) explanation shown under the dashboard KPI tiles.
-_DASHBOARD_EXPLANATION = (
+# One-line methodology note under the KPI row; each KPI's own meaning now lives
+# in its tile's info tooltip.
+_METHODOLOGY_NOTE = (
     "Error-adjusted area estimates and class accuracies from your reference "
-    "sample, following Olofsson et al. (2014). Overall accuracy is the share of "
-    "reference points classified correctly; the charts and tables below break it "
-    "down per class with confidence intervals."
+    "sample, following Olofsson et al. (2014)."
 )
 
 
 @solara.component
-def _KpiCard(label: str, value: str):
-    """A single dashboard stat tile: prominent value + muted label (no icon).
+def _KpiCard(label: str, value: str, hint: str):
+    """A single dashboard stat tile with a corner info button.
 
-    A plain theme-aware ``solara.Card`` (no custom background) so it reads as a
-    normal surface in both light and dark; ``flex: 1`` lets the four share one row.
+    Prominent value + muted label, plus a top-right info button whose tooltip
+    (``hint``) explains the metric. A plain theme-aware ``solara.Card`` (no
+    custom background) so it reads as a normal surface in both light and dark;
+    ``flex: 1`` lets the four share one row, and ``position: relative`` anchors
+    the corner info button.
     """
-    with solara.Card(margin=0, elevation=2, style="flex: 1 1 0; min-width: 0;"):
+    with solara.Card(
+        margin=0,
+        elevation=2,
+        style="flex: 1 1 0; min-width: 0; position: relative;",
+    ):
         with solara.Column(gap="2px", style="align-items: center;"):
             solara.Text(
                 value,
@@ -84,6 +90,18 @@ def _KpiCard(label: str, value: str):
                 classes=["caption"],
                 style="opacity: 0.7; line-height: 1.2; text-align: center;",
             )
+        with solara.Column(
+            gap="0px", style="position: absolute; top: 2px; right: 2px;"
+        ):
+            with solara.Tooltip(hint):
+                solara.v.Btn(
+                    icon=True,
+                    x_small=True,
+                    style_="opacity: 0.5;",
+                    children=[
+                        solara.v.Icon(small=True, children=["mdi-information-outline"])
+                    ],
+                )
 
 
 @solara.component
@@ -91,14 +109,30 @@ def _DashboardKpiCards(results: dict):
     """Overall accuracy / confidence / samples / classes as stat tiles, one row."""
     k = dashboard_kpis(results)
     items = [
-        ("Overall accuracy", f"{k['overall_accuracy_pct']:.1f}%"),
-        ("Confidence level", f"{k['confidence_level']:.0f}%"),
-        ("Reference samples", f"{k['n_samples']:,}"),
-        ("Classes", f"{k['n_classes']}"),
+        (
+            "Overall accuracy",
+            f"{k['overall_accuracy_pct']:.1f}%",
+            "Share of reference points classified correctly.",
+        ),
+        (
+            "Confidence level",
+            f"{k['confidence_level']:.0f}%",
+            "Probability that the ± intervals contain the true value.",
+        ),
+        (
+            "Reference samples",
+            f"{k['n_samples']:,}",
+            "Total reference points assessed.",
+        ),
+        (
+            "Classes",
+            f"{k['n_classes']}",
+            "Number of map classes evaluated.",
+        ),
     ]
     with solara.Row(gap="12px", style="flex-wrap: nowrap; margin-bottom: 8px;"):
-        for label, value in items:
-            _KpiCard(label, value)
+        for label, value, hint in items:
+            _KpiCard(label, value, hint)
 
 
 @solara.component
@@ -130,10 +164,10 @@ def AnalysisDashboardModal(open, theme_toggle=None):
                 solara.v.Html(tag="div", children=[resizer], style_="display: none;")
                 _DashboardKpiCards(results)
                 solara.Text(
-                    _DASHBOARD_EXPLANATION,
+                    _METHODOLOGY_NOTE,
                     style=(
-                        "display: block; text-align: center; opacity: 0.7; "
-                        "font-size: 13px; margin: 0 auto 16px; max-width: 720px;"
+                        "display: block; text-align: center; opacity: 0.6; "
+                        "font-size: 12px; margin: 0 auto 16px; max-width: 640px;"
                     ),
                 )
                 with solara.ColumnsResponsive(6, small=12):

--- a/component/widget/analysis_dashboard.py
+++ b/component/widget/analysis_dashboard.py
@@ -1,6 +1,8 @@
 """Results summary card (KPIs + button) and the analysis dashboard modal it opens."""
 
+import ipyvuetify as ipv
 import solara
+from traitlets import Int, Unicode
 
 from component.model import app_state
 from component.widget.analysis_chart import (
@@ -17,6 +19,33 @@ from component.widget.analysis_results import (
 )
 
 
+class _DialogResizer(ipv.VuetifyTemplate):
+    """Dispatch a window resize event whenever ``tick`` changes.
+
+    ECharts measures zero width when first mounted inside a not-yet-visible
+    dialog, so the charts render tiny. Bumping ``tick`` once the dialog opens
+    forces the widgets to re-layout to their real column width. Mirrors the
+    resize trick used by the sepal-gee-bundle dashboards.
+    """
+
+    tick = Int(0).tag(sync=True)
+    template = Unicode("""
+        <script class='sbae-dashboard-resize'>
+        {
+            watch: {
+                tick() {
+                    this.$nextTick(() => {
+                        setTimeout(() => {
+                            window.dispatchEvent(new Event("resize"));
+                        }, 120);
+                    });
+                }
+            }
+        }
+        </script>
+        """).tag(sync=True)
+
+
 def dashboard_kpis(results: dict) -> dict:
     """Scalar KPIs for the summary card / modal header."""
     rows = results.get("class_estimates", [])
@@ -28,47 +57,96 @@ def dashboard_kpis(results: dict) -> dict:
     }
 
 
+# Short (<= 3 lines) explanation shown under the dashboard KPI tiles.
+_DASHBOARD_EXPLANATION = (
+    "Error-adjusted area estimates and class accuracies from your reference "
+    "sample, following Olofsson et al. (2014). Overall accuracy is the share of "
+    "reference points classified correctly; the charts and tables below break it "
+    "down per class with confidence intervals."
+)
+
+
 @solara.component
-def _DashboardHeader(results: dict):
+def _KpiCard(label: str, value: str):
+    """A single dashboard stat tile: prominent value + muted label (no icon).
+
+    A plain theme-aware ``solara.Card`` (no custom background) so it reads as a
+    normal surface in both light and dark; ``flex: 1`` lets the four share one row.
+    """
+    with solara.Card(margin=0, elevation=2, style="flex: 1 1 0; min-width: 0;"):
+        with solara.Column(gap="2px", style="align-items: center;"):
+            solara.Text(
+                value,
+                style="font-weight: 700; font-size: 22px; line-height: 1.15;",
+            )
+            solara.Text(
+                label,
+                classes=["caption"],
+                style="opacity: 0.7; line-height: 1.2; text-align: center;",
+            )
+
+
+@solara.component
+def _DashboardKpiCards(results: dict):
+    """Overall accuracy / confidence / samples / classes as stat tiles, one row."""
     k = dashboard_kpis(results)
-    with solara.Row(style="align-items: center; gap: 16px; flex-wrap: wrap;"):
-        solara.Text(
-            f"Overall {k['overall_accuracy_pct']:.1f}%",
-            style="font-weight: 700; font-size: 18px;",
-        )
-        solara.Text(f"CL {k['confidence_level']:.0f}%")
-        solara.Text(f"n={k['n_samples']} samples")
-        solara.Text(f"{k['n_classes']} classes")
-        solara.v.Spacer()
-        solara.ToggleButtonsSingle(
-            value=app_state.analysis_area_unit.value,
-            values=["ha", "m2"],
-            on_value=app_state.analysis_area_unit.set,
-        )
+    items = [
+        ("Overall accuracy", f"{k['overall_accuracy_pct']:.1f}%"),
+        ("Confidence level", f"{k['confidence_level']:.0f}%"),
+        ("Reference samples", f"{k['n_samples']:,}"),
+        ("Classes", f"{k['n_classes']}"),
+    ]
+    with solara.Row(gap="12px", style="flex-wrap: nowrap; margin-bottom: 8px;"):
+        for label, value in items:
+            _KpiCard(label, value)
 
 
 @solara.component
 def AnalysisDashboardModal(open, theme_toggle=None):
+    # Hooks must run unconditionally, before the early return, for hook-order
+    # stability across renders (see solara's rules-of-hooks).
+    #
+    # Kick ECharts into a re-layout each time the dialog opens; otherwise the
+    # charts, mounted eagerly while the dialog was hidden, stay tiny.
+    resizer = solara.use_memo(_DialogResizer, [])
+
+    def _resize_on_open():
+        if open.value:
+            resizer.tick += 1
+
+    solara.use_effect(_resize_on_open, [open.value])
+
     results = app_state.analysis_results.value
     if not results:
         return
     unit = app_state.analysis_area_unit.value
+
     with solara.v.Dialog(
         v_model=open.value, on_v_model=open.set, max_width=1100, eager=True
     ):
         with solara.v.Card():
             solara.v.CardTitle(children=["Accuracy assessment results"])
             with solara.v.CardText(style="max-height: 80vh; overflow-y: auto;"):
-                _DashboardHeader(results)
+                solara.v.Html(tag="div", children=[resizer], style_="display: none;")
+                _DashboardKpiCards(results)
+                solara.Text(
+                    _DASHBOARD_EXPLANATION,
+                    style=(
+                        "display: block; text-align: center; opacity: 0.7; "
+                        "font-size: 13px; margin: 0 auto 16px; max-width: 720px;"
+                    ),
+                )
                 with solara.ColumnsResponsive(6, small=12):
                     ConfusionMatrixChart(results, theme_toggle=theme_toggle)
                     AccuracyByClassChart(results, theme_toggle=theme_toggle)
                     AreaEstimateChart(results, unit, theme_toggle=theme_toggle)
                     AreaProportionChart(results, theme_toggle=theme_toggle)
                 with solara.Details("Tables"):
-                    _AreaEstimates(results, unit)
-                    _Accuracy(results)
-                    _ConfusionMatrix(results)
+                    # Space the three tables apart so they don't read as one block.
+                    with solara.Column(style="gap: 28px; padding-top: 8px;"):
+                        _AreaEstimates(results, unit)
+                        _Accuracy(results)
+                        _ConfusionMatrix(results)
             with solara.v.CardActions():
                 solara.v.Spacer()
                 solara.Button("Close", text=True, on_click=lambda: open.set(False))
@@ -84,20 +162,24 @@ def AnalysisSummaryCard(theme_toggle=None):
         return
     k = dashboard_kpis(results)
     with solara.Column(gap="8px"):
-        solara.Text(
-            f"{k['overall_accuracy_pct']:.1f}%",
-            style="font-weight: 700; font-size: 22px;",
-        )
-        solara.Text(
-            f"overall accuracy - CL {k['confidence_level']:.0f}% - "
-            f"n={k['n_samples']} - {k['n_classes']} classes",
-            style="opacity: 0.8;",
-        )
+        # Compact stat chips + one graph, mirroring the design tab's summary
+        # style so both tabs feel consistent.
+        with solara.Row(gap="4px", justify="center", style="flex-wrap: wrap;"):
+            for chip_text in (
+                f"Overall {k['overall_accuracy_pct']:.1f}%",
+                f"CL {k['confidence_level']:.0f}%",
+                f"n={k['n_samples']:,}",
+                f"{k['n_classes']} classes",
+            ):
+                solara.v.Chip(
+                    small=True, label=True, outlined=True, children=[chip_text]
+                )
+        AreaProportionChart(results, theme_toggle=theme_toggle, legend_width=None)
         solara.Button(
-            "Ver dashboard",
-            icon_name="mdi-view-dashboard",
+            "View dashboard",
             color="primary",
             block=True,
+            small=True,
             on_click=lambda: open_modal.set(True),
         )
         _Downloads()

--- a/component/widget/analysis_dashboard.py
+++ b/component/widget/analysis_dashboard.py
@@ -1,4 +1,4 @@
-"""Right-panel results summary + the analysis dashboard modal."""
+"""Results summary card (KPIs + button) and the analysis dashboard modal it opens."""
 
 import solara
 
@@ -13,6 +13,7 @@ from component.widget.analysis_results import (
     _Accuracy,
     _AreaEstimates,
     _ConfusionMatrix,
+    _Downloads,
 )
 
 
@@ -71,3 +72,33 @@ def AnalysisDashboardModal(open, theme_toggle=None):
             with solara.v.CardActions():
                 solara.v.Spacer()
                 solara.Button("Close", text=True, on_click=lambda: open.set(False))
+
+
+@solara.component
+def AnalysisSummaryCard(theme_toggle=None):
+    results = app_state.analysis_results.value
+    # Hook must run unconditionally, before the early return, for hook-order
+    # stability across renders (see solara's rules-of-hooks).
+    open_modal = solara.use_reactive(False)
+    if not results:
+        return
+    k = dashboard_kpis(results)
+    with solara.Column(gap="8px"):
+        solara.Text(
+            f"{k['overall_accuracy_pct']:.1f}%",
+            style="font-weight: 700; font-size: 22px;",
+        )
+        solara.Text(
+            f"overall accuracy - CL {k['confidence_level']:.0f}% - "
+            f"n={k['n_samples']} - {k['n_classes']} classes",
+            style="opacity: 0.8;",
+        )
+        solara.Button(
+            "Ver dashboard",
+            icon_name="mdi-view-dashboard",
+            color="primary",
+            block=True,
+            on_click=lambda: open_modal.set(True),
+        )
+        _Downloads()
+    AnalysisDashboardModal(open_modal, theme_toggle=theme_toggle)

--- a/component/widget/analysis_dashboard.py
+++ b/component/widget/analysis_dashboard.py
@@ -1,0 +1,73 @@
+"""Right-panel results summary + the analysis dashboard modal."""
+
+import solara
+
+from component.model import app_state
+from component.widget.analysis_chart import (
+    AccuracyByClassChart,
+    AreaEstimateChart,
+    AreaProportionChart,
+    ConfusionMatrixChart,
+)
+from component.widget.analysis_results import (
+    _Accuracy,
+    _AreaEstimates,
+    _ConfusionMatrix,
+)
+
+
+def dashboard_kpis(results: dict) -> dict:
+    """Scalar KPIs for the summary card / modal header."""
+    rows = results.get("class_estimates", [])
+    return {
+        "overall_accuracy_pct": round(results.get("overall_accuracy", 0.0) * 100, 1),
+        "confidence_level": results.get("confidence_level", 95.0),
+        "n_samples": int(sum(r.get("number_samples", 0) for r in rows)),
+        "n_classes": len(rows),
+    }
+
+
+@solara.component
+def _DashboardHeader(results: dict):
+    k = dashboard_kpis(results)
+    with solara.Row(style="align-items: center; gap: 16px; flex-wrap: wrap;"):
+        solara.Text(
+            f"Overall {k['overall_accuracy_pct']:.1f}%",
+            style="font-weight: 700; font-size: 18px;",
+        )
+        solara.Text(f"CL {k['confidence_level']:.0f}%")
+        solara.Text(f"n={k['n_samples']} samples")
+        solara.Text(f"{k['n_classes']} classes")
+        solara.v.Spacer()
+        solara.ToggleButtonsSingle(
+            value=app_state.analysis_area_unit.value,
+            values=["ha", "m2"],
+            on_value=app_state.analysis_area_unit.set,
+        )
+
+
+@solara.component
+def AnalysisDashboardModal(open, theme_toggle=None):
+    results = app_state.analysis_results.value
+    if not results:
+        return
+    unit = app_state.analysis_area_unit.value
+    with solara.v.Dialog(
+        v_model=open.value, on_v_model=open.set, max_width=1100, eager=True
+    ):
+        with solara.v.Card():
+            solara.v.CardTitle(children=["Accuracy assessment results"])
+            with solara.v.CardText(style="max-height: 80vh; overflow-y: auto;"):
+                _DashboardHeader(results)
+                with solara.ColumnsResponsive(6, small=12):
+                    ConfusionMatrixChart(results, theme_toggle=theme_toggle)
+                    AccuracyByClassChart(results, theme_toggle=theme_toggle)
+                    AreaEstimateChart(results, unit, theme_toggle=theme_toggle)
+                    AreaProportionChart(results, theme_toggle=theme_toggle)
+                with solara.Details("Tables"):
+                    _AreaEstimates(results, unit)
+                    _Accuracy(results)
+                    _ConfusionMatrix(results)
+            with solara.v.CardActions():
+                solara.v.Spacer()
+                solara.Button("Close", text=True, on_click=lambda: open.set(False))

--- a/component/widget/analysis_results.py
+++ b/component/widget/analysis_results.py
@@ -22,15 +22,6 @@ def AnalysisResultsView(theme_toggle=None):
 
 
 @solara.component
-def _OverallAccuracy(results):
-    oa = results.get("overall_accuracy", 0.0) * 100
-    ci = results.get("confidence_level", 95.0)
-    with solara.Column(gap="4px"):
-        Section("Overall accuracy", "mdi-bullseye-arrow")
-        solara.Markdown(f"**{oa:.1f}%**  ·  confidence level {ci:.0f}%")
-
-
-@solara.component
 def _ConfusionMatrix(results):
     cm = results.get("confusion_matrix")
     if not cm:

--- a/component/widget/analysis_results.py
+++ b/component/widget/analysis_results.py
@@ -12,23 +12,13 @@ def _unit_label(unit: str) -> str:
 
 
 @solara.component
-def AnalysisResultsView():
+def AnalysisResultsView(theme_toggle=None):
     results = app_state.analysis_results.value
     if not results:
         return
-    # Live unit: read the reactive so the ha/m² toggle updates the display
-    # without requiring a recompute (rather than the stale value baked into
-    # the results dict at compute time).
-    unit = app_state.analysis_area_unit.value
-    with solara.Column(style="gap: 14px;"):
-        _OverallAccuracy(results)
-        _ConfusionMatrix(results)
-        _AreaEstimates(results, unit)
-        _Accuracy(results)
-        from component.widget.analysis_chart import AreaEstimateChart  # Task 10
+    from component.widget.analysis_dashboard import AnalysisSummaryCard
 
-        AreaEstimateChart(results, unit)
-        _Downloads()
+    AnalysisSummaryCard(theme_toggle=theme_toggle)
 
 
 @solara.component

--- a/component/widget/analysis_tab.py
+++ b/component/widget/analysis_tab.py
@@ -147,7 +147,7 @@ def CurrentTableDisplay(title: str, df, name: str = "", on_clear=None):
 
 
 @solara.component
-def AnalysisPanel():
+def AnalysisPanel(sbae_map=None):
     """Full analysis panel filling the Analysis tab."""
     reading = solara.use_reactive(False)
     ref_path = solara.use_reactive(None)
@@ -268,7 +268,7 @@ def AnalysisPanel():
             _ColumnMappingCard(
                 list(ref_df.columns), app_state.analysis_area_source.value
             )
-            _AnalysisControls()
+            _AnalysisControls(sbae_map=sbae_map)
             _FilterCard(list(ref_df.columns))
 
         # Results section, always present like the design's Summary: the worked
@@ -357,7 +357,7 @@ def _ColumnMappingCard(columns: list, area_source: str = "upload"):
 
 
 @solara.component
-def _AnalysisControls():
+def _AnalysisControls(sbae_map=None):
     """Area source, confidence level, unit, and optional filter controls."""
     with solara.Column(gap="8px"):
         Section("Options", "mdi-tune")
@@ -379,7 +379,7 @@ def _AnalysisControls():
         if app_state.analysis_area_source.value == "upload":
             _AreaUpload()
         if app_state.analysis_area_source.value == "map":
-            _ClassificationMapUpload()
+            _ClassificationMapUpload(sbae_map=sbae_map)
         solara.Select(
             label="Confidence level (%)",
             value=app_state.analysis_confidence_level.value,
@@ -501,7 +501,7 @@ def _AreaUpload():
 
 
 @solara.component
-def _ClassificationMapUpload():
+def _ClassificationMapUpload(sbae_map=None):
     """Pick a classification GeoTIFF and derive map_code + areas from it.
 
     Samples the raster at each reference point to fill map_code and computes
@@ -530,6 +530,25 @@ def _ClassificationMapUpload():
         app_state.analysis_column_mapping.value = mapping
         app_state.analysis_area_df.value = area_df
         app_state.analysis_reference_df.value = ref_out
+
+        # Already running off-thread (this function is invoked via
+        # asyncio.to_thread by _derive_task below), so call the map methods
+        # directly -- no nested asyncio.to_thread, no sync render-path call.
+        if sbae_map is not None:
+            colors = app_state.class_colors.value or {}
+            sbae_map.add_class_raster(
+                raster, colors, "Classification (analysis)", "clas_an"
+            )
+            sbae_map.add_sample_points(
+                pd.DataFrame(
+                    {
+                        "longitude": ref_out[mapping["x"]],
+                        "latitude": ref_out[mapping["y"]],
+                        "map_code": ref_out["map_code"],
+                    }
+                )
+            )
+
         status.value = (
             f"{len(ref_out)} points sampled, {dropped} dropped "
             "(outside raster / nodata)"

--- a/component/widget/analysis_tab.py
+++ b/component/widget/analysis_tab.py
@@ -531,28 +531,35 @@ def _ClassificationMapUpload(sbae_map=None):
         app_state.analysis_area_df.value = area_df
         app_state.analysis_reference_df.value = ref_out
 
+        status.value = (
+            f"{len(ref_out)} points sampled, {dropped} dropped "
+            "(outside raster / nodata)"
+        )
+
         # Already running off-thread (this function is invoked via
         # asyncio.to_thread by _derive_task below), so call the map methods
         # directly -- no nested asyncio.to_thread, no sync render-path call.
+        # A failure here (e.g. a corrupt raster the tile server can't open)
+        # must not discard the valid analysis results computed above.
         if sbae_map is not None:
-            colors = app_state.class_colors.value or {}
-            sbae_map.add_class_raster(
-                raster, colors, "Classification (analysis)", "clas_an"
-            )
-            sbae_map.add_sample_points(
-                pd.DataFrame(
+            try:
+                colors = app_state.class_colors.value or {}
+                sbae_map.add_class_raster(
+                    raster, colors, "Classification (analysis)", "clas_an"
+                )
+                points = pd.DataFrame(
                     {
                         "longitude": ref_out[mapping["x"]],
                         "latitude": ref_out[mapping["y"]],
                         "map_code": ref_out["map_code"],
                     }
                 )
-            )
-
-        status.value = (
-            f"{len(ref_out)} points sampled, {dropped} dropped "
-            "(outside raster / nodata)"
-        )
+                sbae_map.add_sample_points(points)
+            except Exception as e:  # results are valid; only the map layer failed
+                app_state.add_error(
+                    "Analysis ran, but the classification map could not be "
+                    f"rendered on the map: {e}"
+                )
 
     async def _derive_task():
         await asyncio.to_thread(run_derivation)

--- a/component/widget/analysis_tab.py
+++ b/component/widget/analysis_tab.py
@@ -1,5 +1,6 @@
 """Accuracy-assessment analysis UI: upload -> mapping -> compute -> results."""
 
+import asyncio
 import logging
 from pathlib import Path
 
@@ -264,7 +265,9 @@ def AnalysisPanel():
             )
 
         if ref_loaded:
-            _ColumnMappingCard(list(ref_df.columns))
+            _ColumnMappingCard(
+                list(ref_df.columns), app_state.analysis_area_source.value
+            )
             _AnalysisControls()
             _FilterCard(list(ref_df.columns))
 
@@ -319,7 +322,7 @@ def _ReferenceUploadDialog(ref_path, on_close=None):
 
 
 @solara.component
-def _ColumnMappingCard(columns: list):
+def _ColumnMappingCard(columns: list, area_source: str = "upload"):
     """Dropdowns mapping CSV columns to analysis roles."""
     mapping = app_state.analysis_column_mapping.value
     options = [None, *list(columns)]
@@ -332,13 +335,16 @@ def _ColumnMappingCard(columns: list):
 
         return _set
 
+    map_source = area_source == "map"
     labels = {
         "map": "Map / predicted class *",
         "ref": "Reference class *",
-        "x": "X / longitude",
-        "y": "Y / latitude",
+        "x": "X / longitude *" if map_source else "X / longitude",
+        "y": "Y / latitude *" if map_source else "Y / latitude",
         "sample_area": "Per-sample area (optional)",
     }
+    if map_source:
+        del labels["map"]  # map_code is derived from the raster
     with solara.Column(gap="4px"):
         Section("Column mapping", "mdi-swap-horizontal")
         for role, label in labels.items():
@@ -362,7 +368,7 @@ def _AnalysisControls():
         solara.Select(
             label="Area / strata source",
             value=app_state.analysis_area_source.value,
-            values=["design", "upload"],
+            values=["design", "upload", "map"],
             on_value=lambda v: app_state.analysis_area_source.set(v),
         )
         if app_state.analysis_area_source.value == "design" and not has_design_area:
@@ -372,6 +378,8 @@ def _AnalysisControls():
             )
         if app_state.analysis_area_source.value == "upload":
             _AreaUpload()
+        if app_state.analysis_area_source.value == "map":
+            _ClassificationMapUpload()
         solara.Select(
             label="Confidence level (%)",
             value=app_state.analysis_confidence_level.value,
@@ -490,3 +498,50 @@ def _AreaUpload():
             values=[None, *cols],
             on_value=set_area_role("area_value"),
         )
+
+
+@solara.component
+def _ClassificationMapUpload():
+    """Pick a classification GeoTIFF and derive map_code + areas from it.
+
+    Samples the raster at each reference point to fill map_code and computes
+    the per-class area table — the map is the source of truth.
+    """
+    status = solara.use_reactive("")
+    path = app_state.analysis_classification_path
+
+    def run_derivation():
+        ref = app_state.analysis_reference_df.value
+        raster = path.value
+        if not raster or ref is None or ref.empty:
+            return
+        from component.scripts.accuracy import derive_from_classification
+
+        ref_out, area_df, dropped = derive_from_classification(
+            ref, app_state.analysis_column_mapping.value or {}, raster
+        )
+        mapping = dict(app_state.analysis_column_mapping.value or {})
+        mapping["map"] = "map_code"
+        app_state.analysis_column_mapping.value = mapping
+        app_state.analysis_area_df.value = area_df
+        app_state.analysis_reference_df.value = ref_out
+        status.value = (
+            f"{len(ref_out)} points sampled, {dropped} dropped "
+            "(outside raster / nodata)"
+        )
+
+    async def _derive_task():
+        await asyncio.to_thread(run_derivation)
+
+    solara.lab.use_task(_derive_task, dependencies=[path.value], prefer_threaded=False)
+
+    if path.value:
+        with solara.Row(style="align-items: center; gap: 8px;"):
+            solara.Text(Path(path.value).name)
+            solara.Button(
+                icon_name="mdi-close", icon=True, on_click=lambda: path.set(None)
+            )
+    else:
+        FileInputComponent(extensions=[".tif", ".tiff"], on_value=lambda p: path.set(p))
+    if status.value:
+        solara.Text(status.value, style="opacity: 0.8;")

--- a/component/widget/analysis_tab.py
+++ b/component/widget/analysis_tab.py
@@ -1,7 +1,7 @@
 """Accuracy-assessment analysis UI: upload -> mapping -> compute -> results."""
 
-import asyncio
 import logging
+import os
 from pathlib import Path
 
 import pandas as pd
@@ -54,6 +54,16 @@ _FILTER_HELP = (
     "campaign). Leave empty to use every row."
 )
 
+# Friendly labels for the area/strata source. The internal keys stay
+# "design" / "map" / "upload"; only the dropdown display changes.
+_AREA_SOURCE_LABELS = {
+    "design": "From the design map",
+    "map": "Upload a classification map",
+    "upload": "From an area / strata CSV",
+}
+_AREA_SOURCE_ORDER = ["design", "map", "upload"]
+_AREA_SOURCE_BY_LABEL = {label: key for key, label in _AREA_SOURCE_LABELS.items()}
+
 # Bundled example dataset (collected reference + strata for the aa_test_congo map).
 _EXAMPLE_DIR = (
     Path(__file__).parent.parent.parent / "tests" / "data" / "analysis_example"
@@ -74,8 +84,8 @@ def load_example_analysis_data(state) -> None:
     """Load the bundled example reference + strata into the analysis state.
 
     Self-contained: uses the "upload" area source so it never overwrites the
-    design tab's ``area_data``. The panel's auto-recalc effect then runs the
-    analysis and renders the worked example.
+    design tab's ``area_data``. Loads inputs only -- the dashboard stays blank
+    until the user presses Calculate (results are only computed on that action).
     """
     if not _EXAMPLE_REFERENCE_CSV.exists() or not _EXAMPLE_AREA_CSV.exists():
         state.add_error(f"Example analysis data not found in {_EXAMPLE_DIR}")
@@ -94,6 +104,7 @@ def load_example_analysis_data(state) -> None:
     state.analysis_column_mapping.value = dict(_EXAMPLE_COLUMN_MAPPING)
     state.analysis_confidence_level.value = 95.0
     state.analysis_status.value = ""
+    state.set_analysis_results(None)  # explicit Calculate reveals the result
 
 
 _ROLE_HINTS = {
@@ -116,6 +127,122 @@ def guess_column_mapping(columns: list) -> dict:
                 mapping[role] = match
                 break
     return mapping
+
+
+def derive_map_source(state, sbae_map=None):
+    """Sample the classification raster for the "map" area source.
+
+    Fills ``map_code`` on the reference table by sampling the raster at each
+    point, computes the per-class area table, derives class colors when the
+    design step didn't (standalone mode), and renders the raster on
+    ``sbae_map``. Mutates ``analysis_reference_df`` / ``analysis_area_df`` /
+    ``analysis_column_mapping`` in place. Errors are surfaced via
+    ``state.add_error`` and never raised. Returns the dropped-point count, or
+    ``None`` when there is nothing to derive.
+
+    Called from the Calculate action (``run_calculation``), off the UI thread,
+    so it may block on raster I/O and call the map methods directly.
+    """
+    raster = state.analysis_classification_path.value
+    ref = state.analysis_reference_df.value
+    if not raster or ref is None or ref.empty:
+        return None
+    from component.scripts.accuracy import derive_from_classification
+
+    try:
+        ref_out, area_df, dropped = derive_from_classification(
+            ref, state.analysis_column_mapping.value or {}, raster
+        )
+    except Exception as e:  # surface, don't crash the Calculate task
+        state.add_error(f"Classification-map analysis failed: {e}")
+        return None
+
+    mapping = dict(state.analysis_column_mapping.value or {})
+    mapping["map"] = "map_code"
+    state.analysis_column_mapping.value = mapping
+    state.analysis_area_df.value = area_df
+    state.analysis_reference_df.value = ref_out
+
+    # Standalone mode never runs the design-step upload that populates
+    # class_colors, so it's empty here -- without this, add_class_raster falls
+    # back to a continuous colormap and the map renders near-black. Derive it
+    # from the raster; guarded so a real design-step palette is kept.
+    if not state.class_colors.value:
+        from component.scripts.geospatial import get_color_palette
+
+        state.class_colors.value = get_color_palette(
+            raster, sorted(int(c) for c in area_df["map_code"].tolist())
+        )
+
+    if sbae_map is not None:
+        try:
+            sbae_map.add_class_raster(
+                raster,
+                state.class_colors.value or {},
+                "Classification (analysis)",
+                "clas_an",
+            )
+            # Reference points are drawn by the panel's render thread (from
+            # analysis_reference_df, for every source) on their own layer.
+        except Exception as e:  # results are valid; only the map layer failed
+            state.add_error(
+                "Analysis ran, but the classification map could not be "
+                f"rendered on the map: {e}"
+            )
+    return dropped
+
+
+def run_calculation(state, sbae_map=None):
+    """Run the explicit Calculate action for the analysis tab.
+
+    Derives the map source (if selected), runs the accuracy assessment, and
+    stores the results with their inputs signature.
+    Never raises; user-correctable problems are surfaced via
+    ``state.add_error`` and leave the dashboard blank. Runs off the UI thread
+    (the map source samples a raster), so callers wrap it in ``to_thread``.
+    """
+    if state.analysis_area_source.value == "map":
+        derive_map_source(state, sbae_map)
+
+    if not AnalysisService.is_ready(state):
+        state.set_analysis_results(None)
+        errors = AnalysisService.get_validation_errors(state)
+        state.add_error(
+            "; ".join(errors)
+            if errors
+            else "Provide the required inputs before calculating."
+        )
+        return
+
+    results = AnalysisService.analyze_from_state(state)
+    if results.success:
+        state.set_analysis_results(
+            results.to_dict(), signature=AnalysisService.inputs_signature(state)
+        )
+        if set(results.map_legend) != set(results.ref_legend):
+            note = (
+                "Note: map and reference legends differ; classes present in "
+                "only one are shown with zero-filled values."
+            )
+            if note not in state.error_messages.value:
+                state.add_error(note)
+    else:
+        state.set_analysis_results(None)
+        state.add_error(results.error_message or "Analysis failed")
+
+
+def _results_are_fresh(state) -> bool:
+    """True when the stored results still match the current inputs.
+
+    Calculate stamps the results with a signature of the inputs that produced
+    them; any later edit changes the live signature, so the dashboard is hidden
+    until the user recalculates.
+    """
+    return (
+        state.analysis_results.value is not None
+        and state.analysis_results_signature.value
+        == AnalysisService.inputs_signature(state)
+    )
 
 
 @solara.component
@@ -162,11 +289,12 @@ def CurrentTableDisplay(title: str, df, name: str = "", on_clear=None):
                     color="error",
                     text=True,
                     icon=True,
+                    small=True,
                 )
 
 
 @solara.component
-def AnalysisPanel(sbae_map=None):
+def AnalysisPanel(sbae_map=None, theme_toggle=None):
     """Full analysis panel filling the Analysis tab."""
     reading = solara.use_reactive(False)
     ref_path = solara.use_reactive(None)
@@ -213,36 +341,22 @@ def AnalysisPanel(sbae_map=None):
         app_state.analysis_column_mapping.value = {}
         app_state.set_analysis_results(None)
 
-    # ---- auto-recalc engine (mirrors sample_configuration) ----
-    def recalc():
-        if AnalysisService.is_ready(app_state):
-            results = AnalysisService.analyze_from_state(app_state)
-            if results.success:
-                app_state.set_analysis_results(results.to_dict())
-                if set(results.map_legend) != set(results.ref_legend):
-                    note = (
-                        "Note: map and reference legends differ; classes present in "
-                        "only one are shown with zero-filled values."
-                    )
-                    if note not in app_state.error_messages.value:
-                        app_state.add_error(note)
-            else:
-                app_state.set_analysis_results(None)
-                app_state.add_error(results.error_message or "Analysis failed")
-        else:
-            app_state.set_analysis_results(None)
+    # ---- explicit Calculate action ----
+    # No auto-recalc: results are computed only when the user presses Calculate,
+    # and the dashboard is hidden again as soon as any input changes (see
+    # _results_are_fresh). A trigger counter re-runs the worker on each click;
+    # use_thread (not use_task) keeps it off the UI thread without needing a
+    # running asyncio loop -- matching the panel's other workers.
+    calc_trigger = solara.use_reactive(0)
 
-    solara.use_effect(
-        recalc,
-        [
-            app_state.analysis_reference_df.value,
-            app_state.analysis_column_mapping.value,
-            app_state.area_data.value,
-            app_state.analysis_area_source.value,
-            app_state.analysis_area_df.value,
-            app_state.analysis_confidence_level.value,
-            app_state.analysis_filter.value,
-        ],
+    def _calc_worker():
+        if calc_trigger.value == 0:
+            return None  # don't compute on mount
+        run_calculation(app_state, sbae_map)
+        return calc_trigger.value
+
+    calc_result = solara.use_thread(
+        _calc_worker, dependencies=[calc_trigger.value], intrusive_cancel=False
     )
 
     # Render the analysis reference points on their own map layer (distinct color
@@ -288,6 +402,21 @@ def AnalysisPanel(sbae_map=None):
     ref_df = app_state.analysis_reference_df.value
     ref_loaded = ref_df is not None and not ref_df.empty
 
+    def can_calculate() -> bool:
+        """Enough inputs present to attempt a calculation (per-source file)."""
+        if not ref_loaded:
+            return False
+        source = app_state.analysis_area_source.value
+        if source == "design":
+            area = app_state.area_data.value
+            return area is not None and not area.empty
+        if source == "upload":
+            area = app_state.analysis_area_df.value
+            return area is not None and not area.empty
+        if source == "map":
+            return bool(app_state.analysis_classification_path.value)
+        return False
+
     def close_ref_modal_when_loaded():
         # Once a reference table is loaded (upload or example), close the modal
         # so the "current table" card + downstream controls take over.
@@ -316,7 +445,6 @@ def AnalysisPanel(sbae_map=None):
         else:
             solara.Button(
                 "Upload reference data",
-                icon_name="mdi-upload",
                 on_click=lambda: show_ref_modal.set(True),
                 color="primary",
                 block=True,
@@ -327,13 +455,29 @@ def AnalysisPanel(sbae_map=None):
             _ColumnMappingCard(
                 list(ref_df.columns), app_state.analysis_area_source.value
             )
-            _AnalysisControls(sbae_map=sbae_map)
+            _AnalysisControls()
             _FilterCard(list(ref_df.columns))
 
+            calc_running = calc_result.state in (
+                solara.ResultState.STARTING,
+                solara.ResultState.RUNNING,
+            )
+            solara.Button(
+                "Calculate accuracy assessment",
+                on_click=lambda: calc_trigger.set(calc_trigger.value + 1),
+                color="primary",
+                block=True,
+                small=True,
+                loading=calc_running,
+                disabled=calc_running or not can_calculate(),
+            )
+
         # Results section, always present like the design's Summary: the worked
-        # output once ready, otherwise a hint on what to do next.
-        if app_state.analysis_results.value is not None:
-            AnalysisResultsView()
+        # output once fresh, otherwise a hint on what to do next. Results are
+        # stamped with an inputs signature at Calculate time; once any input
+        # changes the dashboard is hidden until the user recalculates.
+        if _results_are_fresh(app_state):
+            AnalysisResultsView(theme_toggle=theme_toggle)
         elif not ref_loaded:
             solara.Info(
                 "Upload a reference table (or load the example data) to run the "
@@ -341,8 +485,8 @@ def AnalysisPanel(sbae_map=None):
             )
         else:
             solara.Info(
-                "Map the reference and map-class columns to compute the "
-                "accuracy assessment."
+                "Set the area source and column mapping, then press "
+                "**Calculate** to run the accuracy assessment."
             )
 
     # Rendered outside the Column so state changes don't unmount it mid-flow.
@@ -377,7 +521,7 @@ def _ReferenceUploadDialog(ref_path, on_close=None):
                 ExampleDataButton()
         with solara.v.CardActions():
             solara.v.Spacer()
-            solara.Button("Close", text=True, on_click=on_close)
+            solara.Button("Close", text=True, small=True, on_click=on_close)
 
 
 @solara.component
@@ -417,30 +561,36 @@ def _ColumnMappingCard(columns: list, area_source: str = "upload"):
 
 
 @solara.component
-def _AnalysisControls(sbae_map=None):
+def _AnalysisControls():
     """Area source, confidence level, unit, and optional filter controls."""
     with solara.Column(gap="8px"):
         Section("Options", "mdi-tune")
         solara.Markdown(_OPTIONS_HELP)
+        source = app_state.analysis_area_source.value
         has_design_area = (
             app_state.area_data.value is not None
             and not app_state.area_data.value.empty
         )
         solara.Select(
             label="Area / strata source",
-            value=app_state.analysis_area_source.value,
-            values=["design", "upload", "map"],
-            on_value=lambda v: app_state.analysis_area_source.set(v),
+            value=_AREA_SOURCE_LABELS[source],
+            values=[_AREA_SOURCE_LABELS[k] for k in _AREA_SOURCE_ORDER],
+            on_value=lambda label: app_state.analysis_area_source.set(
+                _AREA_SOURCE_BY_LABEL[label]
+            ),
         )
-        if app_state.analysis_area_source.value == "design" and not has_design_area:
-            solara.Warning(
-                "No classification area is loaded from the design step. "
-                "Switch to 'upload' to provide an area CSV."
-            )
-        if app_state.analysis_area_source.value == "upload":
+        if source == "design":
+            if has_design_area:
+                DesignClassificationCard()
+            else:
+                solara.Warning(
+                    "No classification is loaded from the design step. Switch to "
+                    "'Upload a classification map' or 'From an area / strata CSV'."
+                )
+        elif source == "upload":
             _AreaUpload()
-        if app_state.analysis_area_source.value == "map":
-            _ClassificationMapUpload(sbae_map=sbae_map)
+        elif source == "map":
+            _ClassificationMapUpload()
         solara.Select(
             label="Confidence level (%)",
             value=app_state.analysis_confidence_level.value,
@@ -563,90 +713,75 @@ def _AreaUpload():
 
 
 @solara.component
-def _ClassificationMapUpload(sbae_map=None):
-    """Pick a classification GeoTIFF and derive map_code + areas from it.
+def DesignClassificationCard():
+    """Read-only card naming the design-step classification reused as the source.
 
-    Samples the raster at each reference point to fill map_code and computes
-    the per-class area table — the map is the source of truth.
+    Mirrors the design tab's ``CurrentFileDisplay`` minus the clear button --
+    the design step owns that file.
     """
-    status = solara.use_reactive("")
+    file_path = app_state.file_path.value
+    area = app_state.area_data.value
+    name = Path(file_path).name if file_path else "design classification"
+    n_classes = 0 if area is None or area.empty else int(area["map_code"].nunique())
+    class_word = "class" if n_classes == 1 else "classes"
+    with solara.Card(classes=["mb-2"]):
+        with solara.Column(gap="0px"):
+            with solara.Row(gap="6px", style="align-items: baseline;"):
+                solara.Text("Design map:", style="font-weight: 600; font-size: 14px;")
+                solara.Text(name, style="font-size: 14px;")
+            solara.Text(
+                f"{n_classes} {class_word} from the design step",
+                style="font-size: 12px;",
+            )
+
+
+@solara.component
+def CurrentRasterDisplay(path: str, on_clear=None):
+    """Design-style card for the uploaded classification raster (map source).
+
+    Mirrors ``CurrentFileDisplay``: name + type/size and a clear button, instead
+    of a bare filename row.
+    """
+    if not path:
+        return
+    name = Path(path).name
+    try:
+        size_mb = os.path.getsize(path) / (1024 * 1024)
+    except OSError:
+        size_mb = 0.0
+    with solara.Card(classes=["mb-2"]):
+        with solara.Row(justify="space-between", style={"align-items": "center"}):
+            with solara.Column(gap="0px"):
+                with solara.Row(gap="6px", style="align-items: baseline;"):
+                    solara.Text(
+                        "Classification map:",
+                        style="font-weight: 600; font-size: 14px;",
+                    )
+                    solara.Text(name, style="font-size: 14px;")
+                solara.Text(f"GeoTIFF | {size_mb:.1f} MB", style="font-size: 12px;")
+            if on_clear is not None:
+                solara.Button(
+                    label="",
+                    icon_name="mdi-close",
+                    on_click=on_clear,
+                    color="error",
+                    text=True,
+                    icon=True,
+                    small=True,
+                )
+
+
+@solara.component
+def _ClassificationMapUpload():
+    """Pick a classification GeoTIFF for the "map" area source.
+
+    Only selects the file. The raster is sampled (map_code + per-class areas)
+    and rendered when the user presses Calculate -- see ``derive_map_source`` /
+    ``run_calculation``. Clearing the path blanks the dashboard via the inputs
+    signature (the path is part of it), so no explicit reset is needed here.
+    """
     path = app_state.analysis_classification_path
-
-    def run_derivation():
-        ref = app_state.analysis_reference_df.value
-        raster = path.value
-        if not raster or ref is None or ref.empty:
-            return
-        from component.scripts.accuracy import derive_from_classification
-
-        try:
-            ref_out, area_df, dropped = derive_from_classification(
-                ref, app_state.analysis_column_mapping.value or {}, raster
-            )
-        except Exception as e:  # surface, don't crash the page
-            status.value = f"Could not sample the classification map: {e}"
-            app_state.add_error(f"Classification-map analysis failed: {e}")
-            return
-        mapping = dict(app_state.analysis_column_mapping.value or {})
-        mapping["map"] = "map_code"
-        app_state.analysis_column_mapping.value = mapping
-        app_state.analysis_area_df.value = area_df
-        app_state.analysis_reference_df.value = ref_out
-
-        status.value = (
-            f"{len(ref_out)} points sampled, {dropped} dropped "
-            "(outside raster / nodata)"
-        )
-
-        # Standalone mode never runs the design-step upload that populates
-        # class_colors, so it's empty here -- without this, add_class_raster
-        # falls back to a continuous colormap and the map renders near-black.
-        # Populate it from the raster so both the map layer and the dashboard
-        # charts (which also read app_state.class_colors) get consistent
-        # categorical colors. Guarded so a real design-step palette is kept.
-        if not app_state.class_colors.value:
-            from component.scripts.geospatial import get_color_palette
-
-            app_state.class_colors.value = get_color_palette(
-                raster, sorted(int(c) for c in area_df["map_code"].tolist())
-            )
-
-        # Already running off-thread (this function is invoked via
-        # asyncio.to_thread by _derive_task below), so call the map methods
-        # directly -- no nested asyncio.to_thread, no sync render-path call.
-        # A failure here (e.g. a corrupt raster the tile server can't open)
-        # must not discard the valid analysis results computed above.
-        if sbae_map is not None:
-            try:
-                colors = app_state.class_colors.value or {}
-                sbae_map.add_class_raster(
-                    raster, colors, "Classification (analysis)", "clas_an"
-                )
-                # Reference points are drawn by the panel's render thread (from
-                # analysis_reference_df, for every source) on their own layer.
-            except Exception as e:  # results are valid; only the map layer failed
-                app_state.add_error(
-                    "Analysis ran, but the classification map could not be "
-                    f"rendered on the map: {e}"
-                )
-
-    async def _derive_task():
-        await asyncio.to_thread(run_derivation)
-
-    solara.lab.use_task(
-        _derive_task,
-        dependencies=[path.value],
-        prefer_threaded=False,
-        raise_error=False,
-    )
-
     if path.value:
-        with solara.Row(style="align-items: center; gap: 8px;"):
-            solara.Text(Path(path.value).name)
-            solara.Button(
-                icon_name="mdi-close", icon=True, on_click=lambda: path.set(None)
-            )
+        CurrentRasterDisplay(path.value, on_clear=lambda: path.set(None))
     else:
         FileInputComponent(extensions=[".tif", ".tiff"], on_value=lambda p: path.set(p))
-    if status.value:
-        solara.Text(status.value, style="opacity: 0.8;")

--- a/component/widget/analysis_tab.py
+++ b/component/widget/analysis_tab.py
@@ -361,9 +361,9 @@ def AnalysisPanel(sbae_map=None, theme_toggle=None):
 
     # Render the analysis reference points on their own map layer (distinct color
     # + name from the design sample), for every source, whenever the reference
-    # table and its x/y mapping are ready. Build + attach run off the UI thread
-    # (tippecanoe), mirroring the derivation's raster render.
-    def render_reference_points_worker():
+    # table and its x/y mapping are ready. Runs as a use_task: the build offloads
+    # tippecanoe off-thread (open_async) and the attach happens on the loop.
+    async def render_reference_points_worker():
         if sbae_map is None:
             return None
         df = app_state.analysis_reference_df.value
@@ -377,26 +377,35 @@ def AnalysisPanel(sbae_map=None, theme_toggle=None):
             or x not in df.columns
             or y not in df.columns
         ):
+            # Data cleared / not renderable: drop any stale reference layer so
+            # the map stays in sync with the reference table.
+            sbae_map.clear_reference_points()
             return None
-        points = pd.DataFrame(
-            {
-                "longitude": df[x],
-                "latitude": df[y],
-                "map_code": df["map_code"] if "map_code" in df.columns else 0,
-            }
-        )
-        sbae_map.add_reference_points(points)
+        data = {"longitude": df[x], "latitude": df[y]}
+        # map_code / ref_code decide correctness (green vs red). Include each only
+        # when actually known: the map class is absent until the classification
+        # raster is sampled (Calculate), so omitting it leaves the points neutral
+        # rather than falsely "incorrect" against a placeholder.
+        if "map_code" in df.columns:
+            data["map_code"] = df["map_code"]
+        ref_col = mapping.get("ref")
+        if "ref_code" in df.columns:
+            data["ref_code"] = df["ref_code"]
+        elif ref_col and ref_col in df.columns:
+            data["ref_code"] = df[ref_col]
+        points = pd.DataFrame(data)
+        await sbae_map.add_reference_points(points)
         return len(points)
 
     _mapping_now = app_state.analysis_column_mapping.value or {}
-    solara.use_thread(
+    # prefer_threaded defaults to True (non-GEE worker); see point_generation.
+    solara.lab.use_task(
         render_reference_points_worker,
         dependencies=[
             app_state.analysis_reference_df.value,
             _mapping_now.get("x"),
             _mapping_now.get("y"),
         ],
-        intrusive_cancel=False,
     )
 
     ref_df = app_state.analysis_reference_df.value
@@ -455,7 +464,7 @@ def AnalysisPanel(sbae_map=None, theme_toggle=None):
             _ColumnMappingCard(
                 list(ref_df.columns), app_state.analysis_area_source.value
             )
-            _AnalysisControls()
+            _AnalysisControls(sbae_map)
             _FilterCard(list(ref_df.columns))
 
             calc_running = calc_result.state in (
@@ -561,7 +570,7 @@ def _ColumnMappingCard(columns: list, area_source: str = "upload"):
 
 
 @solara.component
-def _AnalysisControls():
+def _AnalysisControls(sbae_map=None):
     """Area source, confidence level, unit, and optional filter controls."""
     with solara.Column(gap="8px"):
         Section("Options", "mdi-tune")
@@ -590,7 +599,7 @@ def _AnalysisControls():
         elif source == "upload":
             _AreaUpload()
         elif source == "map":
-            _ClassificationMapUpload()
+            _ClassificationMapUpload(sbae_map)
         solara.Select(
             label="Confidence level (%)",
             value=app_state.analysis_confidence_level.value,
@@ -772,16 +781,22 @@ def CurrentRasterDisplay(path: str, on_clear=None):
 
 
 @solara.component
-def _ClassificationMapUpload():
+def _ClassificationMapUpload(sbae_map=None):
     """Pick a classification GeoTIFF for the "map" area source.
 
     Only selects the file. The raster is sampled (map_code + per-class areas)
     and rendered when the user presses Calculate -- see ``derive_map_source`` /
-    ``run_calculation``. Clearing the path blanks the dashboard via the inputs
-    signature (the path is part of it), so no explicit reset is needed here.
+    ``run_calculation``. Clearing the path also drops the rendered raster layer
+    (``clas_an``) so it doesn't outlive the data that produced it.
     """
     path = app_state.analysis_classification_path
+
+    def clear_classification():
+        path.set(None)
+        if sbae_map is not None:
+            sbae_map.remove_layer("clas_an", none_ok=True)
+
     if path.value:
-        CurrentRasterDisplay(path.value, on_clear=lambda: path.set(None))
+        CurrentRasterDisplay(path.value, on_clear=clear_classification)
     else:
         FileInputComponent(extensions=[".tif", ".tiff"], on_value=lambda p: path.set(p))

--- a/component/widget/analysis_tab.py
+++ b/component/widget/analysis_tab.py
@@ -567,7 +567,7 @@ def _ClassificationMapUpload(sbae_map=None):
                         "map_code": ref_out["map_code"],
                     }
                 )
-                sbae_map.add_sample_points(points)
+                sbae_map.add_sample_points(points, colors)
             except Exception as e:  # results are valid; only the map layer failed
                 app_state.add_error(
                     "Analysis ran, but the classification map could not be "

--- a/component/widget/analysis_tab.py
+++ b/component/widget/analysis_tab.py
@@ -34,6 +34,26 @@ AA_ANALYSIS_HELP = (
     "confidence intervals, and user's / producer's / overall accuracies."
 )
 
+# Short inline help shown under each section header (kept to 2-3 lines).
+_COLUMN_MAPPING_HELP = (
+    "Match each CSV column to its role. Every reference point needs its "
+    "**mapped class** (`map_code` -- what the classification assigned) and its "
+    "**reference class** (`ref_code` -- the interpreted truth); those two build "
+    "the error matrix. X/Y are required only when the class is read from an "
+    "uploaded map. Fields marked \\* are required."
+)
+_OPTIONS_HELP = (
+    "Where the per-class **areas** (the stratum weights) come from -- the design "
+    "step's classification, a separate area/strata CSV, or a classification map "
+    "you upload here -- plus the **confidence level** for the error-adjusted "
+    "intervals and the **display unit**."
+)
+_FILTER_HELP = (
+    "Optional: restrict the assessment to a subset of reference points -- pick a "
+    "column and keep only the values you choose (e.g. one region, tile, or "
+    "campaign). Leave empty to use every row."
+)
+
 # Bundled example dataset (collected reference + strata for the aa_test_congo map).
 _EXAMPLE_DIR = (
     Path(__file__).parent.parent.parent / "tests" / "data" / "analysis_example"
@@ -132,7 +152,6 @@ def CurrentTableDisplay(title: str, df, name: str = "", on_clear=None):
                     solara.Text(name or "loaded", style="font-size: 14px;")
                 solara.Text(
                     f"{n_rows:,} {row_word}, {n_cols} {col_word}",
-                    classes=["text--secondary"],
                     style="font-size: 12px;",
                 )
             if on_clear is not None:
@@ -224,6 +243,46 @@ def AnalysisPanel(sbae_map=None):
             app_state.analysis_confidence_level.value,
             app_state.analysis_filter.value,
         ],
+    )
+
+    # Render the analysis reference points on their own map layer (distinct color
+    # + name from the design sample), for every source, whenever the reference
+    # table and its x/y mapping are ready. Build + attach run off the UI thread
+    # (tippecanoe), mirroring the derivation's raster render.
+    def render_reference_points_worker():
+        if sbae_map is None:
+            return None
+        df = app_state.analysis_reference_df.value
+        mapping = app_state.analysis_column_mapping.value or {}
+        x, y = mapping.get("x"), mapping.get("y")
+        if (
+            df is None
+            or df.empty
+            or not x
+            or not y
+            or x not in df.columns
+            or y not in df.columns
+        ):
+            return None
+        points = pd.DataFrame(
+            {
+                "longitude": df[x],
+                "latitude": df[y],
+                "map_code": df["map_code"] if "map_code" in df.columns else 0,
+            }
+        )
+        sbae_map.add_reference_points(points)
+        return len(points)
+
+    _mapping_now = app_state.analysis_column_mapping.value or {}
+    solara.use_thread(
+        render_reference_points_worker,
+        dependencies=[
+            app_state.analysis_reference_df.value,
+            _mapping_now.get("x"),
+            _mapping_now.get("y"),
+        ],
+        intrusive_cancel=False,
     )
 
     ref_df = app_state.analysis_reference_df.value
@@ -347,6 +406,7 @@ def _ColumnMappingCard(columns: list, area_source: str = "upload"):
         del labels["map"]  # map_code is derived from the raster
     with solara.Column(gap="4px"):
         Section("Column mapping", "mdi-swap-horizontal")
+        solara.Markdown(_COLUMN_MAPPING_HELP)
         for role, label in labels.items():
             solara.Select(
                 label=label,
@@ -361,6 +421,7 @@ def _AnalysisControls(sbae_map=None):
     """Area source, confidence level, unit, and optional filter controls."""
     with solara.Column(gap="8px"):
         Section("Options", "mdi-tune")
+        solara.Markdown(_OPTIONS_HELP)
         has_design_area = (
             app_state.area_data.value is not None
             and not app_state.area_data.value.empty
@@ -412,6 +473,7 @@ def _FilterCard(columns: list):
 
     with solara.Column(gap="4px"):
         Section("Filter (optional)", "mdi-filter-variant")
+        solara.Markdown(_FILTER_HELP)
         solara.Select(
             label="Filter column",
             value=col,
@@ -560,14 +622,8 @@ def _ClassificationMapUpload(sbae_map=None):
                 sbae_map.add_class_raster(
                     raster, colors, "Classification (analysis)", "clas_an"
                 )
-                points = pd.DataFrame(
-                    {
-                        "longitude": ref_out[mapping["x"]],
-                        "latitude": ref_out[mapping["y"]],
-                        "map_code": ref_out["map_code"],
-                    }
-                )
-                sbae_map.add_sample_points(points, colors)
+                # Reference points are drawn by the panel's render thread (from
+                # analysis_reference_df, for every source) on their own layer.
             except Exception as e:  # results are valid; only the map layer failed
                 app_state.add_error(
                     "Analysis ran, but the classification map could not be "

--- a/component/widget/analysis_tab.py
+++ b/component/widget/analysis_tab.py
@@ -517,9 +517,14 @@ def _ClassificationMapUpload():
             return
         from component.scripts.accuracy import derive_from_classification
 
-        ref_out, area_df, dropped = derive_from_classification(
-            ref, app_state.analysis_column_mapping.value or {}, raster
-        )
+        try:
+            ref_out, area_df, dropped = derive_from_classification(
+                ref, app_state.analysis_column_mapping.value or {}, raster
+            )
+        except Exception as e:  # surface, don't crash the page
+            status.value = f"Could not sample the classification map: {e}"
+            app_state.add_error(f"Classification-map analysis failed: {e}")
+            return
         mapping = dict(app_state.analysis_column_mapping.value or {})
         mapping["map"] = "map_code"
         app_state.analysis_column_mapping.value = mapping
@@ -533,7 +538,12 @@ def _ClassificationMapUpload():
     async def _derive_task():
         await asyncio.to_thread(run_derivation)
 
-    solara.lab.use_task(_derive_task, dependencies=[path.value], prefer_threaded=False)
+    solara.lab.use_task(
+        _derive_task,
+        dependencies=[path.value],
+        prefer_threaded=False,
+        raise_error=False,
+    )
 
     if path.value:
         with solara.Row(style="align-items: center; gap: 8px;"):

--- a/component/widget/analysis_tab.py
+++ b/component/widget/analysis_tab.py
@@ -536,6 +536,19 @@ def _ClassificationMapUpload(sbae_map=None):
             "(outside raster / nodata)"
         )
 
+        # Standalone mode never runs the design-step upload that populates
+        # class_colors, so it's empty here -- without this, add_class_raster
+        # falls back to a continuous colormap and the map renders near-black.
+        # Populate it from the raster so both the map layer and the dashboard
+        # charts (which also read app_state.class_colors) get consistent
+        # categorical colors. Guarded so a real design-step palette is kept.
+        if not app_state.class_colors.value:
+            from component.scripts.geospatial import get_color_palette
+
+            app_state.class_colors.value = get_color_palette(
+                raster, sorted(int(c) for c in area_df["map_code"].tolist())
+            )
+
         # Already running off-thread (this function is invoked via
         # asyncio.to_thread by _derive_task below), so call the map methods
         # directly -- no nested asyncio.to_thread, no sync render-path call.

--- a/component/widget/custom_widgets.py
+++ b/component/widget/custom_widgets.py
@@ -17,14 +17,14 @@ def Section(
     """A theme-aware section header (icon + title + optional description).
 
     Mirrors pysepal's RightPanel section styling with Vuetify theme classes and
-    CSS variables (``subtitle-2``, ``text--secondary``, ``--v-divider-base``)
-    instead of hardcoded colors, so it adapts to light/dark themes. Render it
-    before the section's content.
+    CSS variables (``subtitle-2``, ``--v-divider-base``) instead of hardcoded
+    colors, so it adapts to light/dark themes. Render it before the section's
+    content.
 
     Args:
         title: Section title (shown with theme typography).
         icon: Optional leading MDI icon name.
-        description: Optional muted, theme-aware description line.
+        description: Optional theme-aware description line.
     """
     if title or icon:
         with solara.Row(
@@ -40,7 +40,7 @@ def Section(
     if description:
         solara.Text(
             description,
-            classes=["body-2", "text--secondary"],
+            classes=["body-2"],
             style="padding-left: 16px; margin-bottom: 12px; display: block;",
         )
 

--- a/component/widget/echarts.py
+++ b/component/widget/echarts.py
@@ -1,25 +1,37 @@
 import ipyvuetify as v
+from ipecharts import EChartsRawWidget as BaseEChartsRawWidget
 from ipecharts import EChartsWidget as BaseEChartsWidget
 
 
-class EChartsWidget(BaseEChartsWidget):
-    def __init__(self, theme_toggle=None, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+class _EChartsThemeMixin:
+    """Shared light/dark theming for ipecharts widgets.
 
+    Observes an optional ThemeToggle (or the global ``v.theme``) and keeps the
+    echarts ``theme`` trait in sync. SVG renderer for crisp static output.
+    """
+
+    def _init_theme(self, theme_toggle):
         self.renderer = "svg"
         self.theme_toggle = theme_toggle
         self.theme = self.get_theme()
-
-        if self.theme_toggle:
-            self.theme_toggle.observe(self.set_theme, "dark")
-        else:
-            v.theme.observe(self.set_theme, "dark")
+        target = self.theme_toggle if self.theme_toggle else v.theme
+        target.observe(self.set_theme, "dark")
 
     def get_theme(self):
-
         obj = self.theme_toggle if self.theme_toggle else v.theme
-
         return "dark" if getattr(obj, "dark") else "light"
 
     def set_theme(self, _):
         self.theme = self.get_theme()
+
+
+class EChartsWidget(BaseEChartsWidget, _EChartsThemeMixin):
+    def __init__(self, theme_toggle=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._init_theme(theme_toggle)
+
+
+class RawEChartsWidget(BaseEChartsRawWidget, _EChartsThemeMixin):
+    def __init__(self, theme_toggle=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._init_theme(theme_toggle)

--- a/component/widget/map.py
+++ b/component/widget/map.py
@@ -1,4 +1,5 @@
 import logging
+import shutil
 import tempfile
 
 from localtileserver import TileClient, get_leaflet_tile_layer
@@ -41,6 +42,8 @@ class SbaeMap(SepalMap):
 
         self.classification_layer = None
         self.sample_points_layer = None
+        self.sample_points_dir = None
+        self._pending_points_dir = None
 
     def add_class_raster(
         self,
@@ -139,26 +142,52 @@ class SbaeMap(SepalMap):
 
             class_colors = app_state.class_colors.value or {}
         dest_dir = tempfile.mkdtemp(prefix="sbae_points_")
-        return build_points_pmtiles_layer(points_data, class_colors, dest_dir=dest_dir)
+        try:
+            layer = build_points_pmtiles_layer(
+                points_data, class_colors, dest_dir=dest_dir
+            )
+        except Exception:
+            # Don't leak the dir when the build itself failed.
+            shutil.rmtree(dest_dir, ignore_errors=True)
+            raise
+        self._pending_points_dir = dest_dir
+        return layer
 
     def attach_sample_points_layer(self, layer):
-        """Swap the sample-points layer on the map (call on the main thread)."""
+        """Swap the sample-points layer on the map.
+
+        Mutates the map, so the main thread is preferred. ``add_sample_points``
+        deliberately calls this off the UI thread anyway, matching the
+        pre-existing off-thread ``add_class_raster`` mutation in
+        ``analysis_tab.py``.
+        """
+        old_dir = getattr(self, "sample_points_dir", None)
         if self.sample_points_layer is not None:
             self.remove_layer(self.sample_points_layer)
             self.sample_points_layer = None
+        self.sample_points_dir = None
         if layer is not None:
             self.add_layer(layer, key="sample_pts")
             self.sample_points_layer = layer
+            self.sample_points_dir = getattr(self, "_pending_points_dir", None)
+        self._pending_points_dir = None
+        if old_dir:
+            # Reclaim the previous layer's backing dir now that the swap is done.
+            shutil.rmtree(old_dir, ignore_errors=True)
 
     def add_sample_points(self, points_data, class_colors=None):
         """Build + attach the sample-points PMTiles layer.
 
-        For callers already off the UI thread (e.g. the analysis derivation).
+        Called off the UI thread by the analysis derivation path -- see
+        ``attach_sample_points_layer``'s docstring for why that's fine here.
         On failure, notify and skip -- the map shows no points layer; other
         results are unaffected.
         """
         from component.model import app_state
 
+        # Explicit class dispatch (SbaeMap.foo(self, ...), not self.foo(...)) keeps
+        # this method callable unbound against duck-typed test doubles; for a real
+        # SbaeMap instance it behaves identically to self.foo(...).
         try:
             layer = SbaeMap.build_sample_points_layer(self, points_data, class_colors)
         except VectorTileError as e:

--- a/component/widget/map.py
+++ b/component/widget/map.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import shutil
 import tempfile
 
@@ -110,7 +111,13 @@ class SbaeMap(SepalMap):
                 fit_bounds=fit_bounds,
             )
 
-        client = TileClient(path)
+        # Bind the tile server to a reachable interface when serving the app
+        # over the network (e.g. Solara --host over Tailscale). Defaults to
+        # loopback for local dev; set LOCALTILESERVER_HOST=0.0.0.0 (or the
+        # tailnet IP) plus LOCALTILESERVER_CLIENT_HOST for remote access.
+        client = TileClient(
+            path, host=os.environ.get("LOCALTILESERVER_HOST", "127.0.0.1")
+        )
         layer = get_leaflet_tile_layer(
             client,
             colormap=colormap_arg,

--- a/component/widget/map.py
+++ b/component/widget/map.py
@@ -1,9 +1,14 @@
 import logging
+import tempfile
 
-import ipyleaflet
 from localtileserver import TileClient, get_leaflet_tile_layer
 from sepal_ui.mapping import SepalMap
 from sepal_ui.sepalwidgets.vue_app import ThemeToggle
+
+from component.scripts.vector_tiles import (
+    VectorTileError,
+    build_points_pmtiles_layer,
+)
 
 logger = logging.getLogger("sbae.map")
 
@@ -120,23 +125,44 @@ class SbaeMap(SepalMap):
 
         return layer
 
-    def add_sample_points(self, points_data):
-        """Add sample points layer."""
-        if self.sample_points_layer:
-            logger.debug("Removing existing sample points layer.")
+    def build_sample_points_layer(self, points_data, class_colors=None):
+        """Build (off the UI thread) a PMTiles layer for the sample points.
+
+        Returns ``None`` for an empty DataFrame. Does NOT mutate the map, so it
+        is safe to call from a worker thread. Raises ``VectorTileError`` on
+        failure. ``class_colors=None`` resolves to ``app_state.class_colors``.
+        """
+        if points_data is None or points_data.empty:
+            return None
+        if class_colors is None:
+            from component.model import app_state
+
+            class_colors = app_state.class_colors.value or {}
+        dest_dir = tempfile.mkdtemp(prefix="sbae_points_")
+        return build_points_pmtiles_layer(points_data, class_colors, dest_dir=dest_dir)
+
+    def attach_sample_points_layer(self, layer):
+        """Swap the sample-points layer on the map (call on the main thread)."""
+        if self.sample_points_layer is not None:
             self.remove_layer(self.sample_points_layer)
+            self.sample_points_layer = None
+        if layer is not None:
+            self.add_layer(layer, key="sample_pts")
+            self.sample_points_layer = layer
 
-        if not points_data.empty:
-            markers = []
-            logger.debug(f"Adding {len(points_data)} sample points to the map.")
-            for _, point in points_data.iterrows():
-                marker = ipyleaflet.Marker(
-                    location=(point["latitude"], point["longitude"]),
-                    title=f"Class: {point.get('map_code', 'Unknown')}",
-                )
-                markers.append(marker)
+    def add_sample_points(self, points_data, class_colors=None):
+        """Build + attach the sample-points PMTiles layer.
 
-            logger.debug("Creating marker cluster for sample points.")
+        For callers already off the UI thread (e.g. the analysis derivation).
+        On failure, notify and skip -- the map shows no points layer; other
+        results are unaffected.
+        """
+        from component.model import app_state
 
-            self.sample_points_layer = ipyleaflet.MarkerCluster(markers=markers)
-            self.add_layer(self.sample_points_layer)
+        try:
+            layer = SbaeMap.build_sample_points_layer(self, points_data, class_colors)
+        except VectorTileError as e:
+            logger.warning("Sample points layer failed: %s", e)
+            app_state.add_error(f"Could not render sample points on the map: {e}")
+            return
+        SbaeMap.attach_sample_points_layer(self, layer)

--- a/component/widget/map.py
+++ b/component/widget/map.py
@@ -198,6 +198,17 @@ class SbaeMap(SepalMap):
         self._pending_points_dir = dest_dir
         return layer
 
+    def _zoom_to_points(self, layer):
+        """Zoom to the points layer's own extent, when it has one.
+
+        Layers built via ``vector_tiles`` carry a fit-ready ``.bounds``
+        (``[[S,W],[N,E]]``); a single point yields ``None`` -- nothing sensible to
+        fit -- and the view is left untouched.
+        """
+        bounds = getattr(layer, "bounds", None)
+        if bounds:
+            self.fit_bounds(bounds)
+
     def attach_sample_points_layer(self, layer):
         """Swap the sample-points layer on the map.
 
@@ -215,6 +226,7 @@ class SbaeMap(SepalMap):
             self.add_layer(layer, key="sample_pts")
             self.sample_points_layer = layer
             self.sample_points_dir = getattr(self, "_pending_points_dir", None)
+            SbaeMap._zoom_to_points(self, layer)
         self._pending_points_dir = None
         if old_dir:
             # Reclaim the previous layer's backing dir now that the swap is done.
@@ -274,6 +286,7 @@ class SbaeMap(SepalMap):
             self.add_layer(layer, key="ref_pts")
             self.reference_points_layer = layer
             self.reference_points_dir = getattr(self, "_pending_points_dir", None)
+            SbaeMap._zoom_to_points(self, layer)
         self._pending_points_dir = None
         if old_dir:
             shutil.rmtree(old_dir, ignore_errors=True)

--- a/component/widget/map.py
+++ b/component/widget/map.py
@@ -3,6 +3,8 @@ import os
 import shutil
 import tempfile
 
+import pandas as pd
+import solara
 from localtileserver import TileClient, get_leaflet_tile_layer
 from sepal_ui.mapping import SepalMap
 from sepal_ui.sepalwidgets.vue_app import ThemeToggle
@@ -20,7 +22,7 @@ from component.scripts.vector_tiles import (
 logger = logging.getLogger("sbae.map")
 
 # On-map legend entries (label -> hex). Composed from whichever point layers are
-# currently shown; see ``_points_legend_dict``.
+# currently shown; see ``_compose_points_legend``.
 _SAMPLE_LEGEND_LABEL = "Sample point"
 _CORRECT_LEGEND_LABEL = "Correct"
 _INCORRECT_LEGEND_LABEL = "Incorrect"
@@ -31,6 +33,22 @@ def _hex_to_rgb(hex_color: str) -> tuple:
     """Convert '#rrggbb' to an (r, g, b) tuple."""
     h = hex_color.lstrip("#")
     return tuple(int(h[i : i + 2], 16) for i in (0, 2, 4))
+
+
+def _points_signature(df):
+    """Cheap content signature of a points DataFrame (``None`` when empty).
+
+    Lets ``add_reference_points`` skip the expensive tippecanoe rebuild when the
+    incoming points are unchanged -- switching to the Analysis tab remounts its
+    render task, which re-submits identical points on every entry.
+    """
+    if df is None or df.empty:
+        return None
+    return (
+        len(df),
+        tuple(str(c) for c in df.columns),
+        int(pd.util.hash_pandas_object(df, index=False).sum()),
+    )
 
 
 def _compose_points_legend(
@@ -84,7 +102,10 @@ class SbaeMap(SepalMap):
         # Whether the reference points are coloured by correctness (green/red)
         # vs a single neutral colour -- drives the legend entries.
         self._reference_evaluated = False
-        self._points_legend = None  # the LegendControl, added lazily
+        # Signature of the last-rendered reference points, to skip redundant
+        # rebuilds when the same points are re-submitted (e.g. Analysis-tab
+        # re-entry remounts the render task).
+        self._reference_points_sig = None
 
     def _optimize_for_tiles(self, path) -> str:
         """Return a tiling-optimized (cached COG with overviews) path.
@@ -320,6 +341,16 @@ class SbaeMap(SepalMap):
         """
         from component.model import app_state
 
+        # Unchanged points already on the map -> keep the existing layer and skip
+        # the tippecanoe rebuild (see _points_signature).
+        sig = _points_signature(points_data)
+        if (
+            sig is not None
+            and sig == getattr(self, "_reference_points_sig", None)
+            and self.reference_points_layer is not None
+        ):
+            return
+
         pts = points_data
         color_field = "map_code"
         class_colors = {}
@@ -359,6 +390,7 @@ class SbaeMap(SepalMap):
             self.add_layer(layer, key="ref_pts")
             self.reference_points_layer = layer
             self.reference_points_dir = getattr(self, "_pending_points_dir", None)
+            self._reference_points_sig = sig
             SbaeMap._zoom_to_points(self, layer)
         self._reference_evaluated = evaluated and layer is not None
         self._pending_points_dir = None
@@ -377,6 +409,7 @@ class SbaeMap(SepalMap):
         self.reference_points_layer = None
         self.reference_points_dir = None
         self._reference_evaluated = False
+        self._reference_points_sig = None
         # Remove by the stable "ref_pts" key rather than the tracked object: the
         # map is shared and its widgets can be swapped out from under us (theme
         # change / re-style), leaving the handle stale so an identity lookup would
@@ -387,37 +420,44 @@ class SbaeMap(SepalMap):
             shutil.rmtree(old_dir, ignore_errors=True)
 
     def _refresh_points_legend(self):
-        """Recompose the on-map points legend from the layers currently shown."""
-        legend = _compose_points_legend(
+        """Publish the on-map points legend to reactive state.
+
+        The legend is a declarative Solara overlay (``PointsLegend`` ->
+        pysepal ``LegendComponent``), so this just pushes ``{label: hex}`` to
+        ``app_state.points_legend``; the component re-renders itself. Safe to call
+        from the worker threads that mutate the map.
+        """
+        from component.model import app_state
+
+        app_state.points_legend.value = _compose_points_legend(
             getattr(self, "sample_points_layer", None) is not None,
             getattr(self, "reference_points_layer", None) is not None,
             getattr(self, "_reference_evaluated", False),
         )
-        SbaeMap._apply_points_legend(self, legend)
 
-    def _apply_points_legend(self, legend_dict):
-        """Add/update/remove the legend control; never let it break point render.
 
-        Best-effort: on a duck-typed map double (no ``add``/``remove``) or any
-        widget error it quietly no-ops -- the legend is secondary to the points.
-        """
-        if not (hasattr(self, "add") and hasattr(self, "remove")):
-            return
-        try:
-            current = getattr(self, "_points_legend", None)
-            if not legend_dict:
-                if current is not None:
-                    self.remove(current)
-                    self._points_legend = None
-                return
-            if current is None:
-                from pysepal.mapping.legend_control import LegendControl
+@solara.component
+def PointsLegend():
+    """Floating map legend for the sample/reference points.
 
-                self._points_legend = LegendControl(
-                    legend_dict, title="Points", position="bottomright"
-                )
-                self.add(self._points_legend)
-            else:
-                current.legend_dict = legend_dict
-        except Exception as e:
-            logger.debug("Points legend update skipped: %s", e)
+    Renders the modern pysepal ``LegendComponent`` overlay, driven by
+    ``app_state.points_legend`` ({label: hex}); hidden when there is nothing to
+    show. Place it once in the page alongside the map.
+    """
+    from dataclasses import asdict
+
+    from pysepal.solara.components.legend import (
+        DiscreteEntry,
+        LegendComponent,
+        LegendData,
+    )
+
+    from component.model import app_state
+
+    legend = app_state.points_legend.value or {}
+    data = LegendData(
+        items=[
+            DiscreteEntry(label=label, color=color) for label, color in legend.items()
+        ]
+    )
+    LegendComponent(legend_data=asdict(data), visible=bool(legend))

--- a/component/widget/map.py
+++ b/component/widget/map.py
@@ -51,6 +51,29 @@ class SbaeMap(SepalMap):
         self.reference_points_layer = None
         self.reference_points_dir = None
 
+    def _optimize_for_tiles(self, path) -> str:
+        """Return a tiling-optimized (cached COG with overviews) path.
+
+        rio-tiler reads full-resolution pixels -- and warns ``NoOverviewWarning``
+        -- for every tile when the source has no overviews, so low-zoom tiles are
+        slow. ``prepare_for_tiles`` is a fast no-op when ``path`` is already a
+        tiled COG with overviews (the design step pre-optimizes off-thread); it
+        only does real work for raw rasters such as the analysis classification
+        map, which are added off the UI thread. Best-effort: on failure, serve the
+        raw raster (tiling still works, just slower).
+        """
+        from component.scripts.tiling import prepare_for_tiles
+
+        try:
+            return prepare_for_tiles(str(path))["path"]
+        except Exception as e:
+            logger.warning(
+                "Tiling optimization failed for %s (%s); serving the raw raster.",
+                path,
+                e,
+            )
+            return str(path)
+
     def add_class_raster(
         self,
         path,
@@ -76,6 +99,10 @@ class SbaeMap(SepalMap):
             opacity: layer opacity, default 1.0.
             fit_bounds: whether to recenter/zoom onto the raster.
         """
+        # Build (or reuse a cached) COG with overviews before tiling: rio-tiler
+        # otherwise reads full-res pixels and logs NoOverviewWarning per tile.
+        tile_path = self._optimize_for_tiles(path)
+
         if not class_colors:
             logger.warning(
                 "add_class_raster called without class_colors; "
@@ -83,7 +110,7 @@ class SbaeMap(SepalMap):
                 path,
             )
             return self.add_raster(
-                path,
+                tile_path,
                 layer_name=layer_name,
                 key=key,
                 opacity=opacity,
@@ -109,7 +136,7 @@ class SbaeMap(SepalMap):
                 path,
             )
             return self.add_raster(
-                path,
+                tile_path,
                 layer_name=layer_name,
                 key=key,
                 opacity=opacity,
@@ -121,7 +148,7 @@ class SbaeMap(SepalMap):
         # loopback for local dev; set LOCALTILESERVER_HOST=0.0.0.0 (or the
         # tailnet IP) plus LOCALTILESERVER_CLIENT_HOST for remote access.
         client = TileClient(
-            path, host=os.environ.get("LOCALTILESERVER_HOST", "127.0.0.1")
+            tile_path, host=os.environ.get("LOCALTILESERVER_HOST", "127.0.0.1")
         )
         quiet_tile_server_logs()
         layer = get_leaflet_tile_layer(

--- a/component/widget/map.py
+++ b/component/widget/map.py
@@ -9,17 +9,48 @@ from sepal_ui.sepalwidgets.vue_app import ThemeToggle
 
 from component.scripts.logging_config import quiet_tile_server_logs
 from component.scripts.vector_tiles import (
+    CORRECT_COLOR,
+    INCORRECT_COLOR,
+    REFERENCE_NEUTRAL_COLOR,
+    SAMPLE_POINT_COLOR,
     VectorTileError,
     build_points_pmtiles_layer,
 )
 
 logger = logging.getLogger("sbae.map")
 
+# On-map legend entries (label -> hex). Composed from whichever point layers are
+# currently shown; see ``_points_legend_dict``.
+_SAMPLE_LEGEND_LABEL = "Sample point"
+_CORRECT_LEGEND_LABEL = "Correct"
+_INCORRECT_LEGEND_LABEL = "Incorrect"
+_REFERENCE_LEGEND_LABEL = "Reference point"
+
 
 def _hex_to_rgb(hex_color: str) -> tuple:
     """Convert '#rrggbb' to an (r, g, b) tuple."""
     h = hex_color.lstrip("#")
     return tuple(int(h[i : i + 2], 16) for i in (0, 2, 4))
+
+
+def _compose_points_legend(
+    has_sample: bool, has_reference: bool, reference_evaluated: bool
+) -> dict:
+    """Legend entries (label -> hex) for the point layers currently shown.
+
+    Sample points contribute one neutral entry; reference points contribute the
+    green/red correctness key once evaluated, else a single neutral entry.
+    """
+    legend = {}
+    if has_sample:
+        legend[_SAMPLE_LEGEND_LABEL] = SAMPLE_POINT_COLOR
+    if has_reference:
+        if reference_evaluated:
+            legend[_CORRECT_LEGEND_LABEL] = CORRECT_COLOR
+            legend[_INCORRECT_LEGEND_LABEL] = INCORRECT_COLOR
+        else:
+            legend[_REFERENCE_LEGEND_LABEL] = REFERENCE_NEUTRAL_COLOR
+    return legend
 
 
 def _build_class_colormap(class_colors: dict) -> dict:
@@ -50,6 +81,10 @@ class SbaeMap(SepalMap):
         # design sample points (distinct key/name/color; see add_reference_points).
         self.reference_points_layer = None
         self.reference_points_dir = None
+        # Whether the reference points are coloured by correctness (green/red)
+        # vs a single neutral colour -- drives the legend entries.
+        self._reference_evaluated = False
+        self._points_legend = None  # the LegendControl, added lazily
 
     def _optimize_for_tiles(self, path) -> str:
         """Return a tiling-optimized (cached COG with overviews) path.
@@ -168,33 +203,50 @@ class SbaeMap(SepalMap):
 
         return layer
 
-    def build_sample_points_layer(
-        self, points_data, class_colors=None, *, point_color=None
+    async def build_sample_points_layer(
+        self,
+        points_data,
+        class_colors=None,
+        *,
+        point_color=None,
+        color_field="map_code",
+        radius=5,
+        stroke_width=1,
     ):
         """Build (off the UI thread) a PMTiles layer for the sample points.
 
         Returns ``None`` for an empty DataFrame. Does NOT mutate the map, so it
         is safe to call from a worker thread. Raises ``VectorTileError`` on
-        failure. ``class_colors=None`` resolves to ``app_state.class_colors``.
+        failure. Empty/omitted ``class_colors`` yields a single uniform
+        ``point_color`` layer (design sample points); a non-empty
+        ``class_colors`` colours one flat layer per ``color_field`` value (the
+        analysis green/red).
         """
         if points_data is None or points_data.empty:
             return None
-        if class_colors is None:
-            from component.model import app_state
-
-            class_colors = app_state.class_colors.value or {}
         dest_dir = tempfile.mkdtemp(prefix="sbae_points_")
         try:
-            layer = build_points_pmtiles_layer(
+            layer = await build_points_pmtiles_layer(
                 points_data,
-                class_colors,
+                class_colors or {},
                 dest_dir=dest_dir,
-                default_color=point_color or "#888888",
+                color_field=color_field,
+                default_color=point_color or SAMPLE_POINT_COLOR,
+                radius=radius,
+                stroke_width=stroke_width,
             )
         except Exception:
             # Don't leak the dir when the build itself failed.
             shutil.rmtree(dest_dir, ignore_errors=True)
             raise
+        # Ride in leaflet's overlayPane (z 400) so points always draw above
+        # raster layers: both the PMTiles points and the localtileserver rasters
+        # are GridLayers, and rasters sit in the tilePane (z 200); without this a
+        # classification map added after the points would cover them.
+        try:
+            layer.pane = "overlayPane"
+        except Exception:
+            pass
         self._pending_points_dir = dest_dir
         return layer
 
@@ -219,7 +271,7 @@ class SbaeMap(SepalMap):
         """
         old_dir = getattr(self, "sample_points_dir", None)
         if self.sample_points_layer is not None:
-            self.remove_layer(self.sample_points_layer)
+            self.remove_layer(self.sample_points_layer, none_ok=True)
             self.sample_points_layer = None
         self.sample_points_dir = None
         if layer is not None:
@@ -228,12 +280,13 @@ class SbaeMap(SepalMap):
             self.sample_points_dir = getattr(self, "_pending_points_dir", None)
             SbaeMap._zoom_to_points(self, layer)
         self._pending_points_dir = None
+        SbaeMap._refresh_points_legend(self)
         if old_dir:
             # Reclaim the previous layer's backing dir now that the swap is done.
             shutil.rmtree(old_dir, ignore_errors=True)
 
-    def add_sample_points(self, points_data, class_colors=None):
-        """Build + attach the sample-points PMTiles layer.
+    async def add_sample_points(self, points_data):
+        """Build + attach the design sample-points PMTiles layer (uniform colour).
 
         Called off the UI thread by the analysis derivation path -- see
         ``attach_sample_points_layer``'s docstring for why that's fine here.
@@ -246,28 +299,48 @@ class SbaeMap(SepalMap):
         # this method callable unbound against duck-typed test doubles; for a real
         # SbaeMap instance it behaves identically to self.foo(...).
         try:
-            layer = SbaeMap.build_sample_points_layer(self, points_data, class_colors)
+            layer = await SbaeMap.build_sample_points_layer(
+                self, points_data, point_color=SAMPLE_POINT_COLOR
+            )
         except VectorTileError as e:
             logger.warning("Sample points layer failed: %s", e)
             app_state.add_error(f"Could not render sample points on the map: {e}")
             return
         SbaeMap.attach_sample_points_layer(self, layer)
 
-    def add_reference_points(
-        self, points_data, *, point_color="#ff7f0e", layer_name="Reference points"
-    ):
-        """Render the analysis reference points as their own map layer.
+    async def add_reference_points(self, points_data, *, layer_name="Reference points"):
+        """Render the analysis reference points on their own layer, by agreement.
 
         Kept separate from the design sample (``add_sample_points`` / the
-        ``"sample_pts"`` layer): distinct key (``"ref_pts"``), name, and a uniform
-        ``point_color`` so the two coexist and are visually distinguishable.
-        Builds off the UI thread; on failure, notify and skip.
+        ``"sample_pts"`` layer): distinct key (``"ref_pts"``) and name. When both
+        the map and reference class are known, points are coloured green where
+        they agree (correct) and red where they don't; otherwise (e.g. map class
+        not sampled yet) they fall back to a single neutral colour. Builds off the
+        UI thread; on failure, notify and skip.
         """
         from component.model import app_state
 
+        pts = points_data
+        color_field = "map_code"
+        class_colors = {}
+        evaluated = False
+        if {"map_code", "ref_code"} <= set(pts.columns) and bool(
+            pts[["map_code", "ref_code"]].notna().all(axis=1).all()
+        ):
+            pts = pts.copy()
+            pts["correct"] = (pts["map_code"] == pts["ref_code"]).astype(int)
+            class_colors = {0: INCORRECT_COLOR, 1: CORRECT_COLOR}
+            color_field = "correct"
+            evaluated = True
+
         try:
-            layer = SbaeMap.build_sample_points_layer(
-                self, points_data, {}, point_color=point_color
+            layer = await SbaeMap.build_sample_points_layer(
+                self,
+                pts,
+                class_colors,
+                point_color=REFERENCE_NEUTRAL_COLOR,
+                color_field=color_field,
+                radius=6,
             )
         except VectorTileError as e:
             logger.warning("Reference points layer failed: %s", e)
@@ -275,7 +348,7 @@ class SbaeMap(SepalMap):
             return
         old_dir = self.reference_points_dir
         if self.reference_points_layer is not None:
-            self.remove_layer(self.reference_points_layer)
+            self.remove_layer(self.reference_points_layer, none_ok=True)
             self.reference_points_layer = None
         self.reference_points_dir = None
         if layer is not None:
@@ -287,6 +360,64 @@ class SbaeMap(SepalMap):
             self.reference_points_layer = layer
             self.reference_points_dir = getattr(self, "_pending_points_dir", None)
             SbaeMap._zoom_to_points(self, layer)
+        self._reference_evaluated = evaluated and layer is not None
         self._pending_points_dir = None
+        SbaeMap._refresh_points_legend(self)
         if old_dir:
             shutil.rmtree(old_dir, ignore_errors=True)
+
+    def clear_reference_points(self):
+        """Take the reference-points layer off the map and reclaim its temp dir.
+
+        The inverse of the attach half of ``add_reference_points``: called when
+        the reference data is cleared (or is no longer renderable) so the map
+        layer doesn't outlive the data that produced it.
+        """
+        old_dir = self.reference_points_dir
+        self.reference_points_layer = None
+        self.reference_points_dir = None
+        self._reference_evaluated = False
+        # Remove by the stable "ref_pts" key rather than the tracked object: the
+        # map is shared and its widgets can be swapped out from under us (theme
+        # change / re-style), leaving the handle stale so an identity lookup would
+        # miss the still-visible layer and raise. none_ok: it may already be gone.
+        self.remove_layer("ref_pts", none_ok=True)
+        SbaeMap._refresh_points_legend(self)
+        if old_dir:
+            shutil.rmtree(old_dir, ignore_errors=True)
+
+    def _refresh_points_legend(self):
+        """Recompose the on-map points legend from the layers currently shown."""
+        legend = _compose_points_legend(
+            getattr(self, "sample_points_layer", None) is not None,
+            getattr(self, "reference_points_layer", None) is not None,
+            getattr(self, "_reference_evaluated", False),
+        )
+        SbaeMap._apply_points_legend(self, legend)
+
+    def _apply_points_legend(self, legend_dict):
+        """Add/update/remove the legend control; never let it break point render.
+
+        Best-effort: on a duck-typed map double (no ``add``/``remove``) or any
+        widget error it quietly no-ops -- the legend is secondary to the points.
+        """
+        if not (hasattr(self, "add") and hasattr(self, "remove")):
+            return
+        try:
+            current = getattr(self, "_points_legend", None)
+            if not legend_dict:
+                if current is not None:
+                    self.remove(current)
+                    self._points_legend = None
+                return
+            if current is None:
+                from pysepal.mapping.legend_control import LegendControl
+
+                self._points_legend = LegendControl(
+                    legend_dict, title="Points", position="bottomright"
+                )
+                self.add(self._points_legend)
+            else:
+                current.legend_dict = legend_dict
+        except Exception as e:
+            logger.debug("Points legend update skipped: %s", e)

--- a/component/widget/map.py
+++ b/component/widget/map.py
@@ -7,6 +7,7 @@ from localtileserver import TileClient, get_leaflet_tile_layer
 from sepal_ui.mapping import SepalMap
 from sepal_ui.sepalwidgets.vue_app import ThemeToggle
 
+from component.scripts.logging_config import quiet_tile_server_logs
 from component.scripts.vector_tiles import (
     VectorTileError,
     build_points_pmtiles_layer,
@@ -118,6 +119,7 @@ class SbaeMap(SepalMap):
         client = TileClient(
             path, host=os.environ.get("LOCALTILESERVER_HOST", "127.0.0.1")
         )
+        quiet_tile_server_logs()
         layer = get_leaflet_tile_layer(
             client,
             colormap=colormap_arg,

--- a/component/widget/map.py
+++ b/component/widget/map.py
@@ -46,6 +46,10 @@ class SbaeMap(SepalMap):
         self.sample_points_layer = None
         self.sample_points_dir = None
         self._pending_points_dir = None
+        # Analysis reference points -- a separate layer so they coexist with the
+        # design sample points (distinct key/name/color; see add_reference_points).
+        self.reference_points_layer = None
+        self.reference_points_dir = None
 
     def add_class_raster(
         self,
@@ -137,7 +141,9 @@ class SbaeMap(SepalMap):
 
         return layer
 
-    def build_sample_points_layer(self, points_data, class_colors=None):
+    def build_sample_points_layer(
+        self, points_data, class_colors=None, *, point_color=None
+    ):
         """Build (off the UI thread) a PMTiles layer for the sample points.
 
         Returns ``None`` for an empty DataFrame. Does NOT mutate the map, so it
@@ -153,7 +159,10 @@ class SbaeMap(SepalMap):
         dest_dir = tempfile.mkdtemp(prefix="sbae_points_")
         try:
             layer = build_points_pmtiles_layer(
-                points_data, class_colors, dest_dir=dest_dir
+                points_data,
+                class_colors,
+                dest_dir=dest_dir,
+                default_color=point_color or "#888888",
             )
         except Exception:
             # Don't leak the dir when the build itself failed.
@@ -204,3 +213,40 @@ class SbaeMap(SepalMap):
             app_state.add_error(f"Could not render sample points on the map: {e}")
             return
         SbaeMap.attach_sample_points_layer(self, layer)
+
+    def add_reference_points(
+        self, points_data, *, point_color="#ff7f0e", layer_name="Reference points"
+    ):
+        """Render the analysis reference points as their own map layer.
+
+        Kept separate from the design sample (``add_sample_points`` / the
+        ``"sample_pts"`` layer): distinct key (``"ref_pts"``), name, and a uniform
+        ``point_color`` so the two coexist and are visually distinguishable.
+        Builds off the UI thread; on failure, notify and skip.
+        """
+        from component.model import app_state
+
+        try:
+            layer = SbaeMap.build_sample_points_layer(
+                self, points_data, {}, point_color=point_color
+            )
+        except VectorTileError as e:
+            logger.warning("Reference points layer failed: %s", e)
+            app_state.add_error(f"Could not render reference points on the map: {e}")
+            return
+        old_dir = self.reference_points_dir
+        if self.reference_points_layer is not None:
+            self.remove_layer(self.reference_points_layer)
+            self.reference_points_layer = None
+        self.reference_points_dir = None
+        if layer is not None:
+            try:
+                layer.name = layer_name
+            except Exception:
+                pass
+            self.add_layer(layer, key="ref_pts")
+            self.reference_points_layer = layer
+            self.reference_points_dir = getattr(self, "_pending_points_dir", None)
+        self._pending_points_dir = None
+        if old_dir:
+            shutil.rmtree(old_dir, ignore_errors=True)

--- a/component/widget/point_generation.py
+++ b/component/widget/point_generation.py
@@ -6,6 +6,7 @@ import solara
 
 from component.model import app_state
 from component.scripts.geospatial import generate_sample_points
+from component.scripts.vector_tiles import build_layer_or_notify
 
 logger = logging.getLogger("sbae.point_generation")
 
@@ -105,7 +106,9 @@ def use_point_generation_task(sbae_map=None) -> PointGenerationController:
         request = generation_request.value
         if request is None:
             return None
-        return run_point_generation_request(request)
+        points_df = run_point_generation_request(request)
+        layer = build_layer_or_notify(sbae_map, points_df, app_state.class_colors.value)
+        return (points_df, layer)
 
     generation_result = solara.use_thread(
         generate_points_worker,
@@ -129,15 +132,14 @@ def use_point_generation_task(sbae_map=None) -> PointGenerationController:
             app_state.set_processing_status("")
             generation_request.value = None
         elif generation_result.state == solara.ResultState.FINISHED:
-            points_df = generation_result.value
+            result = generation_result.value
+            points_df = result[0] if result is not None else None
+            layer = result[1] if result is not None else None
             if points_df is not None:
                 app_state.set_sample_points(points_df)
-
-                if sbae_map and not points_df.empty:
-                    logger.info("Adding sample points to map...")
-                    sbae_map.add_sample_points(points_df)
-                    logger.debug(points_df.head())
-
+                if sbae_map and layer is not None:
+                    logger.info("Attaching sample points layer to map...")
+                    sbae_map.attach_sample_points_layer(layer)
                 app_state.points_generation_status.value = POINT_GENERATION_FINISHED
 
             app_state.set_processing_status("")

--- a/component/widget/point_generation.py
+++ b/component/widget/point_generation.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from dataclasses import dataclass
 from typing import Callable
@@ -88,11 +89,8 @@ def run_point_generation_request(request):
     return points_df
 
 
-def _result_is_generating(generation_result, generation_request) -> bool:
-    return generation_request.value is not None and generation_result.state in (
-        solara.ResultState.STARTING,
-        solara.ResultState.RUNNING,
-    )
+def _result_is_generating(generation_task, generation_request) -> bool:
+    return generation_request.value is not None and generation_task.pending
 
 
 def use_point_generation_task(sbae_map=None) -> PointGenerationController:
@@ -102,11 +100,11 @@ def use_point_generation_task(sbae_map=None) -> PointGenerationController:
     generation_request = solara.use_reactive(None)
     request_id_ref = solara.use_ref(0)
 
-    def generate_points_worker():
+    async def generate_points_worker():
         request = generation_request.value
         if request is None:
             return None
-        points_df = run_point_generation_request(request)
+        points_df = await asyncio.to_thread(run_point_generation_request, request)
         # Generation leaves map_code=0; sample the design's classification raster
         # at each point to record its real map class (keep all points -- the
         # sample is fixed, so unsampleable ones stay as generated).
@@ -118,37 +116,42 @@ def use_point_generation_task(sbae_map=None) -> PointGenerationController:
             and "longitude" in points_df.columns
         ):
             try:
-                points_df, _ = extract_map_codes(
-                    points_df, raster, "longitude", "latitude", drop_missing=False
+                points_df, _ = await asyncio.to_thread(
+                    extract_map_codes,
+                    points_df,
+                    raster,
+                    "longitude",
+                    "latitude",
+                    drop_missing=False,
                 )
             except Exception as e:
                 logger.warning("Could not sample map_code from design raster: %s", e)
-        layer = build_layer_or_notify(sbae_map, points_df, app_state.class_colors.value)
+        layer = await build_layer_or_notify(sbae_map, points_df)
         return (points_df, layer)
 
-    generation_result = solara.use_thread(
+    # prefer_threaded defaults to True: this worker is non-GEE (no loop-bound
+    # state), and prefer_threaded=False would need a running loop the sync
+    # solara.render() tests don't provide -- running in a worker thread is fine.
+    generation_task = solara.lab.use_task(
         generate_points_worker,
         dependencies=[generation_request.value],
-        intrusive_cancel=False,
+        raise_error=False,
     )
 
     def handle_generation_result():
         if generation_request.value is None:
             return
 
-        if generation_result.state in (
-            solara.ResultState.STARTING,
-            solara.ResultState.RUNNING,
-        ):
+        if generation_task.pending:
             app_state.points_generation_status.value = POINT_GENERATION_RUNNING
             app_state.set_processing_status("Generating sample points...")
-        elif generation_result.state == solara.ResultState.ERROR:
-            app_state.add_error(f"Error generating points: {generation_result.error}")
+        elif generation_task.error:
+            app_state.add_error(f"Error generating points: {generation_task.exception}")
             app_state.points_generation_status.value = POINT_GENERATION_ERROR
             app_state.set_processing_status("")
             generation_request.value = None
-        elif generation_result.state == solara.ResultState.FINISHED:
-            result = generation_result.value
+        elif generation_task.finished:
+            result = generation_task.value
             points_df = result[0] if result is not None else None
             layer = result[1] if result is not None else None
             if points_df is not None:
@@ -161,13 +164,16 @@ def use_point_generation_task(sbae_map=None) -> PointGenerationController:
             app_state.set_processing_status("")
             generation_request.value = None
 
-    solara.use_effect(handle_generation_result, [generation_result.state])
+    solara.use_effect(
+        handle_generation_result,
+        [generation_task.pending, generation_task.finished, generation_task.error],
+    )
 
     def handle_generate_points():
         """Trigger point generation."""
         if (
             app_state.points_generation_status.value == POINT_GENERATION_RUNNING
-            or _result_is_generating(generation_result, generation_request)
+            or _result_is_generating(generation_task, generation_request)
         ):
             return
 
@@ -198,7 +204,7 @@ def use_point_generation_task(sbae_map=None) -> PointGenerationController:
         custom_seed=custom_seed,
         is_generating=(
             app_state.points_generation_status.value == POINT_GENERATION_RUNNING
-            or _result_is_generating(generation_result, generation_request)
+            or _result_is_generating(generation_task, generation_request)
         ),
         trigger=handle_generate_points,
     )

--- a/component/widget/point_generation.py
+++ b/component/widget/point_generation.py
@@ -5,7 +5,7 @@ from typing import Callable
 import solara
 
 from component.model import app_state
-from component.scripts.geospatial import generate_sample_points
+from component.scripts.geospatial import extract_map_codes, generate_sample_points
 from component.scripts.vector_tiles import build_layer_or_notify
 
 logger = logging.getLogger("sbae.point_generation")
@@ -107,6 +107,22 @@ def use_point_generation_task(sbae_map=None) -> PointGenerationController:
         if request is None:
             return None
         points_df = run_point_generation_request(request)
+        # Generation leaves map_code=0; sample the design's classification raster
+        # at each point to record its real map class (keep all points -- the
+        # sample is fixed, so unsampleable ones stay as generated).
+        raster = app_state.optimized_raster_path.value or app_state.file_path.value
+        if (
+            raster
+            and points_df is not None
+            and not points_df.empty
+            and "longitude" in points_df.columns
+        ):
+            try:
+                points_df, _ = extract_map_codes(
+                    points_df, raster, "longitude", "latitude", drop_missing=False
+                )
+            except Exception as e:
+                logger.warning("Could not sample map_code from design raster: %s", e)
         layer = build_layer_or_notify(sbae_map, points_df, app_state.class_colors.value)
         return (points_df, layer)
 

--- a/component/widget/sample_configuration.py
+++ b/component/widget/sample_configuration.py
@@ -157,7 +157,7 @@ def SampleConfiguration(sbae_map=None, theme_toggle=None):
                 point_generation_controller=point_generation_controller,
             )
         else:
-            AnalysisTab(sbae_map=sbae_map)
+            AnalysisTab(sbae_map=sbae_map, theme_toggle=theme_toggle)
 
 
 @solara.component
@@ -257,11 +257,11 @@ def DesignOutputs(sbae_map=None, theme_toggle=None, point_generation_controller=
 
 
 @solara.component
-def AnalysisTab(sbae_map=None):
+def AnalysisTab(sbae_map=None, theme_toggle=None):
     """Accuracy-assessment analysis (area estimation + accuracies)."""
     from component.widget.analysis_tab import AnalysisPanel
 
-    AnalysisPanel(sbae_map=sbae_map)
+    AnalysisPanel(sbae_map=sbae_map, theme_toggle=theme_toggle)
 
 
 @solara.component

--- a/component/widget/sample_configuration.py
+++ b/component/widget/sample_configuration.py
@@ -157,7 +157,7 @@ def SampleConfiguration(sbae_map=None, theme_toggle=None):
                 point_generation_controller=point_generation_controller,
             )
         else:
-            AnalysisTab()
+            AnalysisTab(sbae_map=sbae_map)
 
 
 @solara.component
@@ -257,11 +257,11 @@ def DesignOutputs(sbae_map=None, theme_toggle=None, point_generation_controller=
 
 
 @solara.component
-def AnalysisTab():
+def AnalysisTab(sbae_map=None):
     """Accuracy-assessment analysis (area estimation + accuracies)."""
     from component.widget.analysis_tab import AnalysisPanel
 
-    AnalysisPanel()
+    AnalysisPanel(sbae_map=sbae_map)
 
 
 @solara.component

--- a/component/widget/summary.py
+++ b/component/widget/summary.py
@@ -53,7 +53,7 @@ def statistics_summary(
         sample_points: Generated sample points
         sampling_method: Current sampling method
     """
-    with solara.Row(gap="4px", style="flex-wrap: wrap;"):
+    with solara.Row(gap="4px", justify="center", style="flex-wrap: wrap;"):
         # Show area based on sampling method
         if (
             sampling_method == "stratified"

--- a/sepal_environment.yml
+++ b/sepal_environment.yml
@@ -21,6 +21,8 @@ dependencies:
   - proj>=9.3
   - pyproj>=3.6
   - pytest>=7.0.0 # for running the test suite
+  # tippecanoe builds the PMTiles vector tiles for the map sample-points layer.
+  - tippecanoe>=2
   - pip:
       # pysepal is the renamed sepal_ui; main has the notification system.
       # The `sepal_ui` import path still works via a compatibility shim.
@@ -28,3 +30,5 @@ dependencies:
       - git+https://github.com/openforis/earthengine-api.git@v1.6.14#egg=earthengine-api&subdirectory=python
       - ipecharts>=1.0.0
       - voila
+      # local vector-tile server for the PMTiles map sample-points layer
+      - vectortileserver>=0.1.0

--- a/sepal_environment.yml
+++ b/sepal_environment.yml
@@ -31,4 +31,4 @@ dependencies:
       - ipecharts>=1.0.0
       - voila
       # local vector-tile server for the PMTiles map sample-points layer
-      - vectortileserver>=0.1.0
+      - vectortileserver>=0.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,19 +4,19 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def _ensure_event_loop():
-    """Guarantee every test starts with a live main-thread event loop.
+def _fresh_event_loop():
+    """Give every test its own live main-thread event loop.
 
     Several tests drive coroutines with ``asyncio.run()``, which closes the loop
     it created and clears the thread's current loop. A later test that calls
-    ``solara.render()`` (which reaches ``asyncio.get_event_loop()``) would then
-    raise "There is no current event loop". Repairing before each test makes the
-    suite order-independent.
+    ``solara.render()`` (reaching ``asyncio.get_event_loop()``) would then raise
+    "There is no current event loop". Installing a fresh loop per test makes the
+    suite order-independent without touching the deprecated ``get_event_loop``.
     """
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     try:
-        loop = asyncio.get_event_loop()
-        if loop.is_closed():
-            raise RuntimeError
-    except RuntimeError:
-        asyncio.set_event_loop(asyncio.new_event_loop())
-    yield
+        yield
+    finally:
+        if not loop.is_closed():
+            loop.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import asyncio
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _ensure_event_loop():
+    """Guarantee every test starts with a live main-thread event loop.
+
+    Several tests drive coroutines with ``asyncio.run()``, which closes the loop
+    it created and clears the thread's current loop. A later test that calls
+    ``solara.render()`` (which reaches ``asyncio.get_event_loop()``) would then
+    raise "There is no current event loop". Repairing before each test makes the
+    suite order-independent.
+    """
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_closed():
+            raise RuntimeError
+    except RuntimeError:
+        asyncio.set_event_loop(asyncio.new_event_loop())
+    yield

--- a/tests/test_analysis_charts.py
+++ b/tests/test_analysis_charts.py
@@ -104,3 +104,40 @@ def test_area_estimate_chart_has_transparent_background():
     widgets = rc.find(EChartsWidget).widgets
     assert len(widgets) == 1
     assert widgets[0].option.backgroundColor == "#1e1e1e00"
+
+
+def test_confusion_matrix_chart_empty_matrix_renders_nothing():
+    results = {"confusion_matrix": {"index": [], "columns": [], "data": []}}
+    _, rc = solara.render(
+        ConfusionMatrixChart(results, theme_toggle=None), handle_error=False
+    )
+    assert len(rc.find(RawEChartsWidget).widgets) == 0
+
+
+def test_accuracy_by_class_chart_empty_renders_nothing():
+    _, rc = solara.render(
+        AccuracyByClassChart({}, theme_toggle=None), handle_error=False
+    )
+    assert len(rc.find(EChartsWidget).widgets) == 0
+
+
+def test_area_proportion_chart_empty_renders_nothing():
+    _, rc = solara.render(
+        AreaProportionChart({}, theme_toggle=None), handle_error=False
+    )
+    assert len(rc.find(EChartsWidget).widgets) == 0
+
+
+def test_area_proportion_chart_all_zero_area_does_not_crash():
+    results = {
+        "class_estimates": [
+            {"class_name": "A", "map_code": 1, "area_estimate": 0.0},
+            {"class_name": "B", "map_code": 2, "area_estimate": 0.0},
+        ]
+    }
+    _, rc = solara.render(
+        AreaProportionChart(results, theme_toggle=None), handle_error=False
+    )
+    assert (
+        len(rc.find(EChartsWidget).widgets) == 1
+    )  # zero-total guard -> no ZeroDivisionError

--- a/tests/test_analysis_charts.py
+++ b/tests/test_analysis_charts.py
@@ -2,10 +2,11 @@
 import solara
 
 from component.widget.analysis_chart import (
+    AccuracyByClassChart,
     ConfusionMatrixChart,
     confusion_heatmap_data,
 )
-from component.widget.echarts import RawEChartsWidget
+from component.widget.echarts import EChartsWidget, RawEChartsWidget
 
 _RESULTS = {
     "confusion_matrix": {
@@ -71,3 +72,14 @@ def test_confusion_matrix_chart_renders_raw_widget():
     assert opt["backgroundColor"] == "#1e1e1e00"
     assert opt["series"][0]["type"] == "heatmap"
     assert "visualMap" in opt
+
+
+def test_accuracy_by_class_chart_two_series():
+    _, rc = solara.render(
+        AccuracyByClassChart(_RESULTS, theme_toggle=None), handle_error=False
+    )
+    widgets = rc.find(EChartsWidget).widgets
+    assert len(widgets) == 1
+    series = widgets[0].option.series
+    assert [s.name for s in series] == ["User's", "Producer's"]
+    assert series[0].data == [80.0, 90.0]

--- a/tests/test_analysis_charts.py
+++ b/tests/test_analysis_charts.py
@@ -1,0 +1,73 @@
+# tests/test_analysis_charts.py
+import solara
+
+from component.widget.analysis_chart import (
+    ConfusionMatrixChart,
+    confusion_heatmap_data,
+)
+from component.widget.echarts import RawEChartsWidget
+
+_RESULTS = {
+    "confusion_matrix": {
+        "index": [11, 12],
+        "columns": [11, 12],
+        "data": [[8, 2], [1, 9]],
+    },
+    "accuracy_rows": [
+        {
+            "class_name": "Forest",
+            "map_code": 11,
+            "users_accuracy": 0.8,
+            "producers_accuracy": 0.89,
+            "weighted_producers_accuracy": 0.87,
+        },
+        {
+            "class_name": "Non-forest",
+            "map_code": 12,
+            "users_accuracy": 0.9,
+            "producers_accuracy": 0.82,
+            "weighted_producers_accuracy": 0.83,
+        },
+    ],
+    "class_estimates": [
+        {
+            "class_name": "Forest",
+            "map_code": 11,
+            "number_samples": 10,
+            "area_estimate": 100.0,
+            "confidence_interval": 5.0,
+            "map_pixel_count": 90.0,
+            "srs_area_estimate": 98.0,
+        },
+        {
+            "class_name": "Non-forest",
+            "map_code": 12,
+            "number_samples": 10,
+            "area_estimate": 50.0,
+            "confidence_interval": 3.0,
+            "map_pixel_count": 60.0,
+            "srs_area_estimate": 52.0,
+        },
+    ],
+}
+
+
+def test_confusion_heatmap_data_shapes():
+    x, y, triples, max_count = confusion_heatmap_data(_RESULTS["confusion_matrix"])
+    assert x == ["11", "12"]
+    assert y == ["11", "12"]
+    assert len(triples) == 4
+    assert [0, 0, 8.0] in triples and [1, 1, 9.0] in triples
+    assert max_count == 9.0
+
+
+def test_confusion_matrix_chart_renders_raw_widget():
+    _, rc = solara.render(
+        ConfusionMatrixChart(_RESULTS, theme_toggle=None), handle_error=False
+    )
+    widgets = rc.find(RawEChartsWidget).widgets
+    assert len(widgets) == 1
+    opt = widgets[0].option
+    assert opt["backgroundColor"] == "#1e1e1e00"
+    assert opt["series"][0]["type"] == "heatmap"
+    assert "visualMap" in opt

--- a/tests/test_analysis_charts.py
+++ b/tests/test_analysis_charts.py
@@ -3,6 +3,7 @@ import solara
 
 from component.widget.analysis_chart import (
     AccuracyByClassChart,
+    AreaProportionChart,
     ConfusionMatrixChart,
     confusion_heatmap_data,
 )
@@ -83,3 +84,13 @@ def test_accuracy_by_class_chart_two_series():
     series = widgets[0].option.series
     assert [s.name for s in series] == ["User's", "Producer's"]
     assert series[0].data == [80.0, 90.0]
+
+
+def test_area_proportion_chart_pie_sums_to_100():
+    _, rc = solara.render(
+        AreaProportionChart(_RESULTS, theme_toggle=None), handle_error=False
+    )
+    widgets = rc.find(EChartsWidget).widgets
+    assert len(widgets) == 1
+    pie = widgets[0].option.series[0]
+    assert round(sum(d["value"] for d in pie.data), 1) == 100.0

--- a/tests/test_analysis_charts.py
+++ b/tests/test_analysis_charts.py
@@ -3,6 +3,7 @@ import solara
 
 from component.widget.analysis_chart import (
     AccuracyByClassChart,
+    AreaEstimateChart,
     AreaProportionChart,
     ConfusionMatrixChart,
     confusion_heatmap_data,
@@ -94,3 +95,12 @@ def test_area_proportion_chart_pie_sums_to_100():
     assert len(widgets) == 1
     pie = widgets[0].option.series[0]
     assert round(sum(d["value"] for d in pie.data), 1) == 100.0
+
+
+def test_area_estimate_chart_has_transparent_background():
+    _, rc = solara.render(
+        AreaEstimateChart(_RESULTS, "ha", theme_toggle=None), handle_error=False
+    )
+    widgets = rc.find(EChartsWidget).widgets
+    assert len(widgets) == 1
+    assert widgets[0].option.backgroundColor == "#1e1e1e00"

--- a/tests/test_analysis_dashboard.py
+++ b/tests/test_analysis_dashboard.py
@@ -1,4 +1,6 @@
 # tests/test_analysis_dashboard.py
+import ipyvuetify as v
+import pytest
 import solara
 
 from component.model import app_state
@@ -6,8 +8,21 @@ from component.widget.analysis_dashboard import (
     AnalysisDashboardModal,
     dashboard_kpis,
 )
+from component.widget.analysis_results import AnalysisResultsView
 from component.widget.echarts import EChartsWidget, RawEChartsWidget
 from tests.test_analysis_charts import _RESULTS
+
+
+@pytest.fixture(autouse=True)
+def _reset_analysis_results():
+    """Reset the shared analysis_results reactive after each test.
+
+    Several tests in this module set ``app_state.analysis_results.value``
+    directly on the shared singleton without resetting it, which could
+    otherwise leak into tests that run later (in this file or others).
+    """
+    yield
+    app_state.analysis_results.value = None
 
 
 def test_dashboard_kpis():
@@ -32,3 +47,17 @@ def test_modal_renders_all_charts_when_open():
     # 3 typed charts (accuracy, area, pie) + 1 raw (heatmap)
     assert len(rc.find(EChartsWidget).widgets) == 3
     assert len(rc.find(RawEChartsWidget).widgets) == 1
+
+
+def test_summary_card_shows_kpis_and_button():
+    app_state.analysis_results.value = {
+        **_RESULTS,
+        "overall_accuracy": 0.85,
+        "confidence_level": 95.0,
+    }
+    _, rc = solara.render(AnalysisResultsView(theme_toggle=None), handle_error=False)
+    text = " ".join(str(c) for w in rc.find(v.Html).widgets for c in (w.children or []))
+    assert "85.0%" in text
+    # a "Ver dashboard" button exists among the rendered buttons
+    labels = [str(c) for b in rc.find(v.Btn).widgets for c in (b.children or [])]
+    assert any("dashboard" in lbl.lower() for lbl in labels)

--- a/tests/test_analysis_dashboard.py
+++ b/tests/test_analysis_dashboard.py
@@ -1,0 +1,34 @@
+# tests/test_analysis_dashboard.py
+import solara
+
+from component.model import app_state
+from component.widget.analysis_dashboard import (
+    AnalysisDashboardModal,
+    dashboard_kpis,
+)
+from component.widget.echarts import EChartsWidget, RawEChartsWidget
+from tests.test_analysis_charts import _RESULTS
+
+
+def test_dashboard_kpis():
+    results = {**_RESULTS, "overall_accuracy": 0.85, "confidence_level": 95.0}
+    k = dashboard_kpis(results)
+    assert k["overall_accuracy_pct"] == 85.0
+    assert k["confidence_level"] == 95.0
+    assert k["n_samples"] == 20
+    assert k["n_classes"] == 2
+
+
+def test_modal_renders_all_charts_when_open():
+    app_state.analysis_results.value = {
+        **_RESULTS,
+        "overall_accuracy": 0.85,
+        "confidence_level": 95.0,
+    }
+    open_r = solara.reactive(True)
+    _, rc = solara.render(
+        AnalysisDashboardModal(open_r, theme_toggle=None), handle_error=False
+    )
+    # 3 typed charts (accuracy, area, pie) + 1 raw (heatmap)
+    assert len(rc.find(EChartsWidget).widgets) == 3
+    assert len(rc.find(RawEChartsWidget).widgets) == 1

--- a/tests/test_analysis_dashboard.py
+++ b/tests/test_analysis_dashboard.py
@@ -56,7 +56,8 @@ def test_summary_card_shows_kpis_and_button():
         "confidence_level": 95.0,
     }
     _, rc = solara.render(AnalysisResultsView(theme_toggle=None), handle_error=False)
-    text = " ".join(str(c) for w in rc.find(v.Html).widgets for c in (w.children or []))
+    # the summary shows the KPI values as chips ("Overall 85.0%", ...)
+    text = " ".join(str(c) for w in rc.find(v.Chip).widgets for c in (w.children or []))
     assert "85.0%" in text
     # a "View dashboard" button exists among the rendered buttons
     labels = [str(c) for b in rc.find(v.Btn).widgets for c in (b.children or [])]

--- a/tests/test_analysis_dashboard.py
+++ b/tests/test_analysis_dashboard.py
@@ -58,6 +58,6 @@ def test_summary_card_shows_kpis_and_button():
     _, rc = solara.render(AnalysisResultsView(theme_toggle=None), handle_error=False)
     text = " ".join(str(c) for w in rc.find(v.Html).widgets for c in (w.children or []))
     assert "85.0%" in text
-    # a "Ver dashboard" button exists among the rendered buttons
+    # a "View dashboard" button exists among the rendered buttons
     labels = [str(c) for b in rc.find(v.Btn).widgets for c in (b.children or [])]
     assert any("dashboard" in lbl.lower() for lbl in labels)

--- a/tests/test_analysis_service.py
+++ b/tests/test_analysis_service.py
@@ -45,3 +45,19 @@ def test_not_ready_when_no_reference():
     st.analysis_reference_df = _R(pd.DataFrame())
     assert AnalysisService.is_ready(st) is False
     assert AnalysisService.get_validation_errors(st)
+
+
+def test_create_inputs_map_source_uses_area_df():
+    from component.model.state_manager import AppState
+
+    st = AppState()
+    st.analysis_reference_df.value = pd.DataFrame(
+        {"map_code": [1, 2], "ref_code": [1, 1]}
+    )
+    st.analysis_column_mapping.value = {"map": "map_code", "ref": "ref_code"}
+    st.analysis_area_df.value = pd.DataFrame(
+        {"map_code": [1, 2], "map_area": [100.0, 50.0]}
+    )
+    st.analysis_area_source.value = "map"
+    inputs = AnalysisService.create_inputs_from_state(st)
+    assert list(inputs.area_data["map_area"]) == [100.0, 50.0]

--- a/tests/test_analysis_ui_widgets.py
+++ b/tests/test_analysis_ui_widgets.py
@@ -151,9 +151,10 @@ def test_section_uses_theme_aware_classes_not_hardcoded_colors():
     htmls = rc.find(v.Html).widgets
     title = next(w for w in htmls if "Summary" in (w.children or []))
     assert "subtitle-2" in (title.class_ or "")
-    # Description is theme-aware muted text, not a hardcoded gray.
+    # Description inherits the theme text color rather than a hardcoded gray.
     desc = next(w for w in htmls if "A description" in (w.children or []))
-    assert "text--secondary" in (desc.class_ or "")
+    assert "body-2" in (desc.class_ or "")
+    assert "text--secondary" not in (desc.class_ or "")
     assert "#" not in (desc.style_ or "")
     assert any(
         "mdi-progress-check" in (i.children or []) for i in rc.find(v.Icon).widgets
@@ -294,6 +295,7 @@ class _FakeSbaeMap:
     def __init__(self):
         self.class_raster_calls = []
         self.sample_points_calls = []
+        self.reference_points_calls = []
 
     def add_class_raster(self, path, class_colors, layer_name, key):
         self.class_raster_calls.append(
@@ -308,9 +310,12 @@ class _FakeSbaeMap:
     def add_sample_points(self, points_df, class_colors=None):
         self.sample_points_calls.append((points_df, class_colors))
 
+    def add_reference_points(self, points_df, **kwargs):
+        self.reference_points_calls.append((points_df, kwargs))
+
 
 def test_classification_map_upload_renders_layers_on_success(monkeypatch, tmp_path):
-    """A successful derivation adds the classification raster + ref points to sbae_map.
+    """A successful derivation adds the classification raster to sbae_map.
 
     Drives the real ``use_task`` derivation (real rasterio round-trip, same
     fixture as ``test_derive_from_classification.py``) with a fake ``sbae_map``
@@ -369,15 +374,10 @@ def test_classification_map_upload_renders_layers_on_success(monkeypatch, tmp_pa
     assert call["class_colors"], "class_colors must not be empty (near-black map)"
     assert set(call["class_colors"]) == {1, 2, 3, 4}
 
-    assert len(fake_map.sample_points_calls) == 1
-    points_df, colors = fake_map.sample_points_calls[0]
-    assert set(points_df.columns) >= {"latitude", "longitude", "map_code"}
-    assert points_df["map_code"].tolist() == [1, 4]
-    assert points_df["longitude"].tolist() == [0.5, 2.5]
-    assert points_df["latitude"].tolist() == [3.5, 0.5]
-    # Task 5 wiring: the derived class_colors must be passed through to the
-    # sample-points layer too, not just the classification raster.
-    assert colors == st.class_colors.value
+    # Reference points are no longer rendered by the derivation itself: the
+    # AnalysisPanel's render thread draws them (from analysis_reference_df, for
+    # every source) on their own "ref_pts" layer. The derivation adds the raster.
+    assert fake_map.sample_points_calls == []
 
 
 def test_classification_map_upload_skips_layers_without_sbae_map(monkeypatch, tmp_path):

--- a/tests/test_analysis_ui_widgets.py
+++ b/tests/test_analysis_ui_widgets.py
@@ -3,8 +3,11 @@
 import asyncio
 
 import ipyvuetify as v
+import numpy as np
 import pandas as pd
+import rasterio
 import solara
+from rasterio.transform import from_origin
 
 from component.model import app_state
 from component.model.state_manager import AppState
@@ -274,3 +277,132 @@ def test_classification_map_upload_survives_derivation_error(monkeypatch, tmp_pa
     assert any(
         "x/y column mapping" in msg for msg in st.error_messages.value
     ), st.error_messages.value
+
+
+def test_analysis_panel_accepts_sbae_map():
+    import inspect
+
+    from component.widget.analysis_tab import AnalysisPanel
+
+    fn = getattr(AnalysisPanel, "f", AnalysisPanel)
+    assert "sbae_map" in inspect.signature(fn).parameters
+
+
+class _FakeSbaeMap:
+    """Records add_class_raster/add_sample_points calls instead of a real map."""
+
+    def __init__(self):
+        self.class_raster_calls = []
+        self.sample_points_calls = []
+
+    def add_class_raster(self, path, class_colors, layer_name, key):
+        self.class_raster_calls.append(
+            {
+                "path": path,
+                "class_colors": class_colors,
+                "layer_name": layer_name,
+                "key": key,
+            }
+        )
+
+    def add_sample_points(self, points_df):
+        self.sample_points_calls.append(points_df)
+
+
+def test_classification_map_upload_renders_layers_on_success(monkeypatch, tmp_path):
+    """A successful derivation adds the classification raster + ref points to sbae_map.
+
+    Drives the real ``use_task`` derivation (real rasterio round-trip, same
+    fixture as ``test_derive_from_classification.py``) with a fake ``sbae_map``
+    standing in for ``SbaeMap``, so this exercises the actual success-path
+    wiring rather than asserting it by inspection.
+    """
+    data = np.array(
+        [[1, 1, 2, 2], [1, 1, 2, 2], [3, 3, 4, 4], [3, 3, 4, 4]], dtype=np.uint8
+    )
+    raster_path = tmp_path / "clas.tif"
+    with rasterio.open(
+        raster_path,
+        "w",
+        driver="GTiff",
+        height=data.shape[0],
+        width=data.shape[1],
+        count=1,
+        dtype=data.dtype,
+        crs="EPSG:4326",
+        transform=from_origin(0, 4, 1, 1),
+    ) as dst:
+        dst.write(data, 1)
+
+    st = AppState()
+    st.analysis_reference_df.value = pd.DataFrame(
+        {"lon": [0.5, 2.5], "lat": [3.5, 0.5], "ref_code": [1, 2]}
+    )
+    st.analysis_column_mapping.value = {"x": "lon", "y": "lat", "ref": "ref_code"}
+    st.analysis_classification_path.value = str(raster_path)
+    st.class_colors.value = {1: "#ff0000", 2: "#00ff00", 3: "#0000ff", 4: "#ffff00"}
+    monkeypatch.setattr(analysis_tab, "app_state", st)
+
+    fake_map = _FakeSbaeMap()
+
+    async def _runner():
+        element = analysis_tab._ClassificationMapUpload.widget(sbae_map=fake_map)
+        # Let the use_task's background thread run the derivation and the
+        # resulting re-render settle (see pysepal's export-test pattern).
+        for _ in range(20):
+            await asyncio.sleep(0.05)
+        return element
+
+    _run_with_task_loop(_runner)
+
+    assert len(fake_map.class_raster_calls) == 1
+    call = fake_map.class_raster_calls[0]
+    assert call["path"] == str(raster_path)
+    assert call["class_colors"] == st.class_colors.value
+    assert call["key"] == "clas_an"
+
+    assert len(fake_map.sample_points_calls) == 1
+    points_df = fake_map.sample_points_calls[0]
+    assert set(points_df.columns) >= {"latitude", "longitude", "map_code"}
+    assert points_df["map_code"].tolist() == [1, 4]
+    assert points_df["longitude"].tolist() == [0.5, 2.5]
+    assert points_df["latitude"].tolist() == [3.5, 0.5]
+
+
+def test_classification_map_upload_skips_layers_without_sbae_map(monkeypatch, tmp_path):
+    """No sbae_map -> derivation still succeeds; no AttributeError from a None map."""
+    data = np.array(
+        [[1, 1, 2, 2], [1, 1, 2, 2], [3, 3, 4, 4], [3, 3, 4, 4]], dtype=np.uint8
+    )
+    raster_path = tmp_path / "clas.tif"
+    with rasterio.open(
+        raster_path,
+        "w",
+        driver="GTiff",
+        height=data.shape[0],
+        width=data.shape[1],
+        count=1,
+        dtype=data.dtype,
+        crs="EPSG:4326",
+        transform=from_origin(0, 4, 1, 1),
+    ) as dst:
+        dst.write(data, 1)
+
+    st = AppState()
+    st.analysis_reference_df.value = pd.DataFrame(
+        {"lon": [0.5, 2.5], "lat": [3.5, 0.5], "ref_code": [1, 2]}
+    )
+    st.analysis_column_mapping.value = {"x": "lon", "y": "lat", "ref": "ref_code"}
+    st.analysis_classification_path.value = str(raster_path)
+    monkeypatch.setattr(analysis_tab, "app_state", st)
+
+    async def _runner():
+        element = analysis_tab._ClassificationMapUpload.widget()  # sbae_map=None
+        for _ in range(20):
+            await asyncio.sleep(0.05)
+        return element
+
+    _run_with_task_loop(_runner)
+
+    assert st.analysis_reference_df.value["map_code"].tolist() == [1, 4]
+    assert not st.error_messages.value

--- a/tests/test_analysis_ui_widgets.py
+++ b/tests/test_analysis_ui_widgets.py
@@ -340,7 +340,10 @@ def test_classification_map_upload_renders_layers_on_success(monkeypatch, tmp_pa
     )
     st.analysis_column_mapping.value = {"x": "lon", "y": "lat", "ref": "ref_code"}
     st.analysis_classification_path.value = str(raster_path)
-    st.class_colors.value = {1: "#ff0000", 2: "#00ff00", 3: "#0000ff", 4: "#ffff00"}
+    # Standalone mode: class_colors starts EMPTY, as it would with no
+    # design-step upload. run_derivation must derive it from the raster
+    # (see test assertions below) instead of leaving it empty.
+    assert st.class_colors.value == {}
     monkeypatch.setattr(analysis_tab, "app_state", st)
 
     fake_map = _FakeSbaeMap()
@@ -360,6 +363,11 @@ def test_classification_map_upload_renders_layers_on_success(monkeypatch, tmp_pa
     assert call["path"] == str(raster_path)
     assert call["class_colors"] == st.class_colors.value
     assert call["key"] == "clas_an"
+    # The map layer must never fall back to a continuous colormap: with no
+    # design-step upload, class_colors starts empty and run_derivation must
+    # derive it from the raster (one entry per class present in the raster).
+    assert call["class_colors"], "class_colors must not be empty (near-black map)"
+    assert set(call["class_colors"]) == {1, 2, 3, 4}
 
     assert len(fake_map.sample_points_calls) == 1
     points_df = fake_map.sample_points_calls[0]

--- a/tests/test_analysis_ui_widgets.py
+++ b/tests/test_analysis_ui_widgets.py
@@ -1,11 +1,14 @@
 """UI-widget tests for the analysis tab: current-table card and download menu."""
 
+import asyncio
+
 import ipyvuetify as v
 import pandas as pd
 import solara
 
 from component.model import app_state
 from component.model.state_manager import AppState
+from component.widget import analysis_tab
 from component.widget.analysis_results import _ConfusionMatrix
 from component.widget.analysis_tab import (
     AnalysisPanel,
@@ -201,3 +204,73 @@ def test_column_mapping_hides_map_role_for_map_source(monkeypatch):
     labels = " ".join(str(s.label) for s in rc.find(v.Select).widgets)
     assert "Reference class" in labels
     assert "Map / predicted" not in labels  # map role hidden when the map derives it
+
+
+def _walk_widgets(widget):
+    yield widget
+    for child in getattr(widget, "children", ()) or ():
+        yield from _walk_widgets(child)
+
+
+def _run_with_task_loop(coro_factory):
+    """Run ``coro_factory()`` on a real event loop, then restore loop state.
+
+    ``asyncio.run`` unconditionally clears the process' "current" event loop
+    when it tears down, which sticks for the rest of the test session and
+    breaks later tests that rely on ``asyncio.get_event_loop()``'s legacy
+    auto-create fallback (e.g. solara's task runner). Save whatever loop was
+    current beforehand and restore it afterward so this test stays isolated.
+    """
+    try:
+        previous_loop = asyncio.get_event_loop_policy().get_event_loop()
+    except RuntimeError:
+        previous_loop = None
+    try:
+        return asyncio.run(coro_factory())
+    finally:
+        asyncio.set_event_loop(previous_loop)
+
+
+def test_classification_map_upload_survives_derivation_error(monkeypatch, tmp_path):
+    """A raster picked before x/y mapping must not crash the whole widget tree.
+
+    Regression test for a bug where ``derive_from_classification`` raising
+    inside the ``use_task`` derivation (e.g. because x/y columns aren't
+    mapped yet) propagated out of render: with reacton's default
+    ``handle_error=True`` the whole widget tree -- clear button included --
+    gets replaced by a raw traceback ``ipywidgets.HTML``, wedging the page.
+    Verified empirically against the pre-fix code: the tree collapsed to a
+    single traceback widget and the clear button vanished. Post-fix the
+    error is caught, surfaced via ``status`` + ``app_state.add_error``, and
+    the normal widget tree (clear button included) is preserved.
+    """
+    raster_path = tmp_path / "classification.tif"
+    raster_path.write_bytes(b"")  # never opened: the x/y check raises first
+
+    st = AppState()
+    st.analysis_reference_df.value = pd.DataFrame(
+        {"x": [1, 2], "y": [3, 4], "ref_code": [1, 2]}
+    )
+    st.analysis_column_mapping.value = {}  # x/y NOT mapped yet
+    st.analysis_classification_path.value = str(raster_path)
+    monkeypatch.setattr(analysis_tab, "app_state", st)
+
+    async def _runner():
+        element = analysis_tab._ClassificationMapUpload.widget()
+        # Let the use_task's background thread run the derivation and the
+        # resulting re-render settle (see pysepal's export-test pattern).
+        for _ in range(20):
+            await asyncio.sleep(0.05)
+        return element
+
+    element = _run_with_task_loop(_runner)
+
+    widgets = list(_walk_widgets(element))
+    # No raw traceback widget replaced the tree.
+    assert not [w for w in widgets if type(w).__name__ == "HTML"]
+    # The clear (mdi-close) button is still there -- the session isn't stuck.
+    assert [w for w in widgets if isinstance(w, v.Btn)]
+    # The error is surfaced through the app's error channel.
+    assert any(
+        "x/y column mapping" in msg for msg in st.error_messages.value
+    ), st.error_messages.value

--- a/tests/test_analysis_ui_widgets.py
+++ b/tests/test_analysis_ui_widgets.py
@@ -1,7 +1,5 @@
 """UI-widget tests for the analysis tab: current-table card and download menu."""
 
-import asyncio
-
 import ipyvuetify as v
 import numpy as np
 import pandas as pd
@@ -9,6 +7,7 @@ import rasterio
 import solara
 from rasterio.transform import from_origin
 
+from component.analysis.service import AnalysisService
 from component.model import app_state
 from component.model.state_manager import AppState
 from component.widget import analysis_tab
@@ -210,43 +209,12 @@ def test_column_mapping_hides_map_role_for_map_source(monkeypatch):
     assert "Map / predicted" not in labels  # map role hidden when the map derives it
 
 
-def _walk_widgets(widget):
-    yield widget
-    for child in getattr(widget, "children", ()) or ():
-        yield from _walk_widgets(child)
+def test_derive_map_source_surfaces_error_without_xy_mapping(tmp_path):
+    """derive_map_source must not raise when x/y columns aren't mapped.
 
-
-def _run_with_task_loop(coro_factory):
-    """Run ``coro_factory()`` on a real event loop, then restore loop state.
-
-    ``asyncio.run`` unconditionally clears the process' "current" event loop
-    when it tears down, which sticks for the rest of the test session and
-    breaks later tests that rely on ``asyncio.get_event_loop()``'s legacy
-    auto-create fallback (e.g. solara's task runner). Save whatever loop was
-    current beforehand and restore it afterward so this test stays isolated.
-    """
-    try:
-        previous_loop = asyncio.get_event_loop_policy().get_event_loop()
-    except RuntimeError:
-        previous_loop = None
-    try:
-        return asyncio.run(coro_factory())
-    finally:
-        asyncio.set_event_loop(previous_loop)
-
-
-def test_classification_map_upload_survives_derivation_error(monkeypatch, tmp_path):
-    """A raster picked before x/y mapping must not crash the whole widget tree.
-
-    Regression test for a bug where ``derive_from_classification`` raising
-    inside the ``use_task`` derivation (e.g. because x/y columns aren't
-    mapped yet) propagated out of render: with reacton's default
-    ``handle_error=True`` the whole widget tree -- clear button included --
-    gets replaced by a raw traceback ``ipywidgets.HTML``, wedging the page.
-    Verified empirically against the pre-fix code: the tree collapsed to a
-    single traceback widget and the clear button vanished. Post-fix the
-    error is caught, surfaced via ``status`` + ``app_state.add_error``, and
-    the normal widget tree (clear button included) is preserved.
+    The Calculate action runs this off the UI thread; a raised exception would
+    abort the task. Instead the error is surfaced via ``app_state.add_error``
+    and the reference table is left untouched (no partial map_code column).
     """
     raster_path = tmp_path / "classification.tif"
     raster_path.write_bytes(b"")  # never opened: the x/y check raises first
@@ -257,27 +225,15 @@ def test_classification_map_upload_survives_derivation_error(monkeypatch, tmp_pa
     )
     st.analysis_column_mapping.value = {}  # x/y NOT mapped yet
     st.analysis_classification_path.value = str(raster_path)
-    monkeypatch.setattr(analysis_tab, "app_state", st)
 
-    async def _runner():
-        element = analysis_tab._ClassificationMapUpload.widget()
-        # Let the use_task's background thread run the derivation and the
-        # resulting re-render settle (see pysepal's export-test pattern).
-        for _ in range(20):
-            await asyncio.sleep(0.05)
-        return element
+    result = analysis_tab.derive_map_source(st, None)  # must not raise
 
-    element = _run_with_task_loop(_runner)
-
-    widgets = list(_walk_widgets(element))
-    # No raw traceback widget replaced the tree.
-    assert not [w for w in widgets if type(w).__name__ == "HTML"]
-    # The clear (mdi-close) button is still there -- the session isn't stuck.
-    assert [w for w in widgets if isinstance(w, v.Btn)]
-    # The error is surfaced through the app's error channel.
+    assert result is None
     assert any(
         "x/y column mapping" in msg for msg in st.error_messages.value
     ), st.error_messages.value
+    # reference table untouched -- no map_code column was added
+    assert "map_code" not in st.analysis_reference_df.value.columns
 
 
 def test_analysis_panel_accepts_sbae_map():
@@ -314,18 +270,11 @@ class _FakeSbaeMap:
         self.reference_points_calls.append((points_df, kwargs))
 
 
-def test_classification_map_upload_renders_layers_on_success(monkeypatch, tmp_path):
-    """A successful derivation adds the classification raster to sbae_map.
-
-    Drives the real ``use_task`` derivation (real rasterio round-trip, same
-    fixture as ``test_derive_from_classification.py``) with a fake ``sbae_map``
-    standing in for ``SbaeMap``, so this exercises the actual success-path
-    wiring rather than asserting it by inspection.
-    """
+def _write_2x2_class_raster(raster_path):
+    """4x4 raster of four 2x2 class blocks (1 top-left, 2 top-right, 3, 4)."""
     data = np.array(
         [[1, 1, 2, 2], [1, 1, 2, 2], [3, 3, 4, 4], [3, 3, 4, 4]], dtype=np.uint8
     )
-    raster_path = tmp_path / "clas.tif"
     with rasterio.open(
         raster_path,
         "w",
@@ -338,6 +287,17 @@ def test_classification_map_upload_renders_layers_on_success(monkeypatch, tmp_pa
         transform=from_origin(0, 4, 1, 1),
     ) as dst:
         dst.write(data, 1)
+
+
+def test_derive_map_source_renders_raster_layer(tmp_path):
+    """derive_map_source samples the raster, fills map_code, and adds the layer.
+
+    Also derives class colors from the raster (standalone mode). Real rasterio
+    round-trip (same fixture as ``test_derive_from_classification``) with a fake
+    ``sbae_map`` -- exercises the actual success path, no rendering.
+    """
+    raster_path = tmp_path / "clas.tif"
+    _write_2x2_class_raster(raster_path)
 
     st = AppState()
     st.analysis_reference_df.value = pd.DataFrame(
@@ -346,58 +306,35 @@ def test_classification_map_upload_renders_layers_on_success(monkeypatch, tmp_pa
     st.analysis_column_mapping.value = {"x": "lon", "y": "lat", "ref": "ref_code"}
     st.analysis_classification_path.value = str(raster_path)
     # Standalone mode: class_colors starts EMPTY, as it would with no
-    # design-step upload. run_derivation must derive it from the raster
-    # (see test assertions below) instead of leaving it empty.
+    # design-step upload. derive_map_source must derive it from the raster.
     assert st.class_colors.value == {}
-    monkeypatch.setattr(analysis_tab, "app_state", st)
 
     fake_map = _FakeSbaeMap()
+    dropped = analysis_tab.derive_map_source(st, fake_map)
 
-    async def _runner():
-        element = analysis_tab._ClassificationMapUpload.widget(sbae_map=fake_map)
-        # Let the use_task's background thread run the derivation and the
-        # resulting re-render settle (see pysepal's export-test pattern).
-        for _ in range(20):
-            await asyncio.sleep(0.05)
-        return element
-
-    _run_with_task_loop(_runner)
-
+    assert dropped == 0
     assert len(fake_map.class_raster_calls) == 1
     call = fake_map.class_raster_calls[0]
     assert call["path"] == str(raster_path)
     assert call["class_colors"] == st.class_colors.value
     assert call["key"] == "clas_an"
     # The map layer must never fall back to a continuous colormap: with no
-    # design-step upload, class_colors starts empty and run_derivation must
+    # design-step upload, class_colors starts empty and derive_map_source must
     # derive it from the raster (one entry per class present in the raster).
     assert call["class_colors"], "class_colors must not be empty (near-black map)"
     assert set(call["class_colors"]) == {1, 2, 3, 4}
-
-    # Reference points are no longer rendered by the derivation itself: the
-    # AnalysisPanel's render thread draws them (from analysis_reference_df, for
-    # every source) on their own "ref_pts" layer. The derivation adds the raster.
+    # map_code filled on the reference + mapping updated to the derived column
+    assert st.analysis_column_mapping.value["map"] == "map_code"
+    assert st.analysis_reference_df.value["map_code"].tolist() == [1, 4]
+    # Reference points are drawn by the AnalysisPanel's render thread (on their
+    # own "ref_pts" layer), not by the derivation.
     assert fake_map.sample_points_calls == []
 
 
-def test_classification_map_upload_skips_layers_without_sbae_map(monkeypatch, tmp_path):
-    """No sbae_map -> derivation still succeeds; no AttributeError from a None map."""
-    data = np.array(
-        [[1, 1, 2, 2], [1, 1, 2, 2], [3, 3, 4, 4], [3, 3, 4, 4]], dtype=np.uint8
-    )
+def test_derive_map_source_without_sbae_map(tmp_path):
+    """No sbae_map -> derivation still fills map_code; no AttributeError."""
     raster_path = tmp_path / "clas.tif"
-    with rasterio.open(
-        raster_path,
-        "w",
-        driver="GTiff",
-        height=data.shape[0],
-        width=data.shape[1],
-        count=1,
-        dtype=data.dtype,
-        crs="EPSG:4326",
-        transform=from_origin(0, 4, 1, 1),
-    ) as dst:
-        dst.write(data, 1)
+    _write_2x2_class_raster(raster_path)
 
     st = AppState()
     st.analysis_reference_df.value = pd.DataFrame(
@@ -405,15 +342,139 @@ def test_classification_map_upload_skips_layers_without_sbae_map(monkeypatch, tm
     )
     st.analysis_column_mapping.value = {"x": "lon", "y": "lat", "ref": "ref_code"}
     st.analysis_classification_path.value = str(raster_path)
-    monkeypatch.setattr(analysis_tab, "app_state", st)
 
-    async def _runner():
-        element = analysis_tab._ClassificationMapUpload.widget()  # sbae_map=None
-        for _ in range(20):
-            await asyncio.sleep(0.05)
-        return element
+    dropped = analysis_tab.derive_map_source(st, None)  # sbae_map=None
 
-    _run_with_task_loop(_runner)
-
+    assert dropped == 0
     assert st.analysis_reference_df.value["map_code"].tolist() == [1, 4]
     assert not st.error_messages.value
+
+
+# ---- explicit Calculate flow: signature, freshness, button, source labels ----
+
+
+def test_inputs_signature_changes_when_an_input_changes():
+    st = AppState()
+    st.analysis_reference_df.value = pd.DataFrame({"m": [1], "r": [1]})
+    st.analysis_reference_name.value = "ref.csv"
+    sig1 = AnalysisService.inputs_signature(st)
+    st.analysis_confidence_level.value = 90.0
+    assert AnalysisService.inputs_signature(st) != sig1
+
+
+def test_inputs_signature_stable_when_nothing_changes():
+    st = AppState()
+    st.analysis_reference_df.value = pd.DataFrame({"m": [1], "r": [1]})
+    assert AnalysisService.inputs_signature(st) == AnalysisService.inputs_signature(st)
+
+
+def test_results_are_fresh_tracks_input_edits():
+    st = AppState()
+    st.analysis_reference_df.value = pd.DataFrame({"m": [1], "r": [1]})
+    st.set_analysis_results(
+        {"overall_accuracy": 0.9}, signature=AnalysisService.inputs_signature(st)
+    )
+    assert analysis_tab._results_are_fresh(st) is True
+    # any later edit invalidates the stored results -> dashboard hidden
+    st.analysis_confidence_level.value = 90.0
+    assert analysis_tab._results_are_fresh(st) is False
+
+
+def test_set_analysis_results_none_clears_signature():
+    st = AppState()
+    st.set_analysis_results({"x": 1}, signature=("sig",))
+    st.set_analysis_results(None)
+    assert st.analysis_results.value is None
+    assert st.analysis_results_signature.value is None
+
+
+def test_run_calculation_design_source_sets_fresh_results():
+    st = AppState()
+    st.area_data.value = pd.DataFrame(
+        {
+            "map_code": [1, 2],
+            "map_area": [600000.0, 400000.0],
+            "map_edited_class": ["Forest", "NonForest"],
+        }
+    )
+    rows = [(1, 1)] * 45 + [(1, 2)] * 5 + [(2, 1)] * 10 + [(2, 2)] * 40
+    st.analysis_reference_df.value = pd.DataFrame(rows, columns=["mapc", "refc"])
+    st.analysis_column_mapping.value = {"map": "mapc", "ref": "refc"}
+    st.analysis_area_source.value = "design"
+
+    analysis_tab.run_calculation(st, None)
+
+    assert st.analysis_results.value is not None
+    assert analysis_tab._results_are_fresh(st) is True
+
+
+def test_run_calculation_without_inputs_reports_error_and_stays_blank():
+    st = AppState()
+    st.analysis_reference_df.value = pd.DataFrame()  # nothing loaded
+    analysis_tab.run_calculation(st, None)
+    assert st.analysis_results.value is None
+    assert st.error_messages.value  # a validation error surfaced
+
+
+def test_area_source_labels_are_bijective():
+    assert set(analysis_tab._AREA_SOURCE_LABELS) == {"design", "upload", "map"}
+    # order presented to the user: design map, upload a map, area CSV
+    assert analysis_tab._AREA_SOURCE_ORDER == ["design", "map", "upload"]
+    for key, label in analysis_tab._AREA_SOURCE_LABELS.items():
+        assert analysis_tab._AREA_SOURCE_BY_LABEL[label] == key
+
+
+def test_area_source_select_shows_friendly_labels_not_raw_keys(monkeypatch):
+    st = AppState()
+    st.analysis_area_source.value = "map"
+    monkeypatch.setattr(analysis_tab, "app_state", st)
+    _, rc = solara.render(analysis_tab._AnalysisControls(), handle_error=False)
+    src = next(s for s in rc.find(v.Select).widgets if "source" in str(s.label).lower())
+    # current selection renders as the friendly label, never the raw key
+    assert src.v_model == "Upload a classification map"
+    items = [str(x) for x in (src.items or [])]
+    assert "Upload a classification map" in items
+    assert "map" not in items and "design" not in items
+
+
+def test_design_source_shows_classification_card(monkeypatch, tmp_path):
+    st = AppState()
+    st.analysis_area_source.value = "design"
+    st.file_path.value = str(tmp_path / "my_design.tif")
+    st.area_data.value = pd.DataFrame(
+        {"map_code": [1, 2, 3], "map_area": [1.0, 2.0, 3.0]}
+    )
+    monkeypatch.setattr(analysis_tab, "app_state", st)
+    _, rc = solara.render(analysis_tab._AnalysisControls(), handle_error=False)
+    text = _html_text(rc)
+    assert "Design map:" in text
+    assert "my_design.tif" in text
+    assert "3 classes" in text
+
+
+def test_classification_map_upload_shows_card_when_path_set(monkeypatch, tmp_path):
+    raster = tmp_path / "clas.tif"
+    raster.write_bytes(b"")
+    st = AppState()
+    st.analysis_classification_path.value = str(raster)
+    monkeypatch.setattr(analysis_tab, "app_state", st)
+    _, rc = solara.render(analysis_tab._ClassificationMapUpload(), handle_error=False)
+    text = _html_text(rc)
+    assert "Classification map:" in text
+    assert "clas.tif" in text
+    rc.find(v.Btn).assert_single()  # the clear button
+
+
+def test_analysis_panel_shows_calculate_button_when_reference_loaded(monkeypatch):
+    st = AppState()
+    st.analysis_reference_df.value = pd.DataFrame({"mapc": [1, 2], "refc": [1, 2]})
+    st.analysis_reference_name.value = "ref.csv"
+    st.analysis_column_mapping.value = {"map": "mapc", "ref": "refc"}
+    st.analysis_area_source.value = "design"
+    st.area_data.value = pd.DataFrame({"map_code": [1, 2], "map_area": [1.0, 2.0]})
+    monkeypatch.setattr(analysis_tab, "app_state", st)
+    _, rc = solara.render(analysis_tab.AnalysisPanel(), handle_error=False)
+    labels = " ".join(
+        str(c) for b in rc.find(v.Btn).widgets for c in (b.children or [])
+    )
+    assert "Calculate" in labels

--- a/tests/test_analysis_ui_widgets.py
+++ b/tests/test_analysis_ui_widgets.py
@@ -305,8 +305,8 @@ class _FakeSbaeMap:
             }
         )
 
-    def add_sample_points(self, points_df):
-        self.sample_points_calls.append(points_df)
+    def add_sample_points(self, points_df, class_colors=None):
+        self.sample_points_calls.append((points_df, class_colors))
 
 
 def test_classification_map_upload_renders_layers_on_success(monkeypatch, tmp_path):
@@ -370,11 +370,14 @@ def test_classification_map_upload_renders_layers_on_success(monkeypatch, tmp_pa
     assert set(call["class_colors"]) == {1, 2, 3, 4}
 
     assert len(fake_map.sample_points_calls) == 1
-    points_df = fake_map.sample_points_calls[0]
+    points_df, colors = fake_map.sample_points_calls[0]
     assert set(points_df.columns) >= {"latitude", "longitude", "map_code"}
     assert points_df["map_code"].tolist() == [1, 4]
     assert points_df["longitude"].tolist() == [0.5, 2.5]
     assert points_df["latitude"].tolist() == [3.5, 0.5]
+    # Task 5 wiring: the derived class_colors must be passed through to the
+    # sample-points layer too, not just the classification raster.
+    assert colors == st.class_colors.value
 
 
 def test_classification_map_upload_skips_layers_without_sbae_map(monkeypatch, tmp_path):

--- a/tests/test_analysis_ui_widgets.py
+++ b/tests/test_analysis_ui_widgets.py
@@ -5,6 +5,7 @@ import pandas as pd
 import solara
 
 from component.model import app_state
+from component.model.state_manager import AppState
 from component.widget.analysis_results import _ConfusionMatrix
 from component.widget.analysis_tab import (
     AnalysisPanel,
@@ -182,3 +183,21 @@ def test_section_without_description_renders_only_title_text():
     ]
     assert len(text_spans) == 1
     assert "Generate Points" in (text_spans[0].children or [])
+
+
+def test_column_mapping_hides_map_role_for_map_source(monkeypatch):
+    from component.widget import analysis_tab
+
+    st = AppState()
+    st.analysis_area_source.value = "map"
+    st.analysis_column_mapping.value = {}
+    monkeypatch.setattr(analysis_tab, "app_state", st)
+    _, rc = solara.render(
+        analysis_tab._ColumnMappingCard(["a", "b"], area_source="map"),
+        handle_error=False,
+    )
+    # Select labels are a v.Select widget trait (rendered client-side by
+    # Vuetify), not v.Html children, so inspect the Select widgets directly.
+    labels = " ".join(str(s.label) for s in rc.find(v.Select).widgets)
+    assert "Reference class" in labels
+    assert "Map / predicted" not in labels  # map role hidden when the map derives it

--- a/tests/test_analysis_workflow.py
+++ b/tests/test_analysis_workflow.py
@@ -2,14 +2,32 @@
 
 import numpy as np
 import pandas as pd
+import rasterio
+from rasterio.transform import from_origin
 
 from component.analysis.service import AnalysisService
 from component.model.state_manager import AppState
+from component.scripts.accuracy import derive_from_classification
 from component.widget.analysis_tab import (
     AnalysisPanel,
     guess_column_mapping,
     load_example_analysis_data,
 )
+
+
+def _write(path, data):
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=data.shape[0],
+        width=data.shape[1],
+        count=1,
+        dtype=data.dtype,
+        crs="EPSG:4326",
+        transform=from_origin(0, 4, 1, 1),
+    ) as dst:
+        dst.write(data, 1)
 
 
 def test_guess_column_mapping_matches_common_headers():
@@ -69,3 +87,33 @@ def test_load_example_analysis_data_runs_analysis():
     # area estimates sum to A_total (native units of the strata file)
     total_area = sum(c.area_estimate for c in res.class_estimates)
     assert np.isclose(total_area, res.total_area)
+
+
+def test_standalone_map_analysis_end_to_end(tmp_path):
+    data = np.array(
+        [[1, 1, 2, 2], [1, 1, 2, 2], [3, 3, 4, 4], [3, 3, 4, 4]], dtype=np.uint8
+    )
+    p = tmp_path / "clas.tif"
+    _write(p, data)
+    ref = pd.DataFrame(
+        {
+            "lon": [0.5, 1.5, 2.5, 3.5, 0.5, 3.5],
+            "lat": [3.5, 3.5, 0.5, 0.5, 0.5, 3.5],
+            "ref_code": [1, 1, 4, 4, 3, 2],
+        }
+    )
+    mapping = {"x": "lon", "y": "lat", "ref": "ref_code"}
+    ref_out, area_df, dropped = derive_from_classification(ref, mapping, str(p))
+    assert dropped == 0
+
+    st = AppState()
+    st.analysis_reference_df.value = ref_out
+    st.analysis_area_df.value = area_df
+    st.analysis_area_source.value = "map"
+    st.analysis_column_mapping.value = {**mapping, "map": "map_code"}
+    st.analysis_confidence_level.value = 95.0
+    results = AnalysisService.analyze_from_state(st)
+    assert results.success
+    d = results.to_dict()
+    assert d["confusion_matrix"] is not None
+    assert len(d["class_estimates"]) >= 1

--- a/tests/test_analysis_workflow.py
+++ b/tests/test_analysis_workflow.py
@@ -115,5 +115,14 @@ def test_standalone_map_analysis_end_to_end(tmp_path):
     results = AnalysisService.analyze_from_state(st)
     assert results.success
     d = results.to_dict()
-    assert d["confusion_matrix"] is not None
-    assert len(d["class_estimates"]) >= 1
+    # every reference point's map_code == ref_code by construction -> perfect accuracy
+    assert d["overall_accuracy"] == 1.0
+    assert len(d["class_estimates"]) == 4
+    # each of 4 classes covers 4 of 16 unit-area pixels -> per-class 4.0, total 16.0
+    assert sum(c["area_estimate"] for c in d["class_estimates"]) == 16.0
+    # perfect agreement => diagonal confusion matrix (no off-diagonal confusion)
+    cm = d["confusion_matrix"]
+    for i, row in enumerate(cm["data"]):
+        for j, val in enumerate(row):
+            if i != j:
+                assert val == 0

--- a/tests/test_derive_from_classification.py
+++ b/tests/test_derive_from_classification.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pandas as pd
+import rasterio
+from rasterio.transform import from_origin
+
+from component.scripts.accuracy import derive_from_classification
+
+
+def _write(path, data):
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=data.shape[0],
+        width=data.shape[1],
+        count=1,
+        dtype=data.dtype,
+        crs="EPSG:4326",
+        transform=from_origin(0, 4, 1, 1),
+    ) as dst:
+        dst.write(data, 1)
+
+
+def test_derive_fills_map_code_and_areas(tmp_path):
+    data = np.array(
+        [[1, 1, 2, 2], [1, 1, 2, 2], [3, 3, 4, 4], [3, 3, 4, 4]], dtype=np.uint8
+    )
+    p = tmp_path / "clas.tif"
+    _write(p, data)
+    ref = pd.DataFrame({"lon": [0.5, 2.5], "lat": [3.5, 0.5], "ref_code": [1, 2]})
+    mapping = {"x": "lon", "y": "lat", "ref": "ref_code"}
+    ref_out, area_out, dropped = derive_from_classification(ref, mapping, str(p))
+    assert dropped == 0
+    assert ref_out["map_code"].tolist() == [1, 4]
+    assert set(area_out.columns) >= {"map_code", "map_area"}
+    assert sorted(area_out["map_code"].tolist()) == [1, 2, 3, 4]

--- a/tests/test_echarts_theme.py
+++ b/tests/test_echarts_theme.py
@@ -1,0 +1,24 @@
+# tests/test_echarts_theme.py
+from component.widget.echarts import EChartsWidget, RawEChartsWidget
+
+
+class _Toggle:
+    dark = True
+
+    def observe(self, *_args, **_kwargs):
+        pass
+
+
+def test_raw_widget_binds_toggle_and_theme():
+    tt = _Toggle()
+    w = RawEChartsWidget(theme_toggle=tt, option={"series": []})
+    assert w.theme_toggle is tt
+    assert w.theme == "dark"
+    assert w.renderer == "svg"
+
+
+def test_typed_widget_still_themes():
+    tt = _Toggle()
+    w = EChartsWidget(theme_toggle=tt)
+    assert w.theme == "dark"
+    assert w.renderer == "svg"

--- a/tests/test_extract_map_codes.py
+++ b/tests/test_extract_map_codes.py
@@ -46,6 +46,29 @@ def test_drops_out_of_bounds(tmp_path):
     assert out["map_code"].tolist() == [1]
 
 
+def test_keeps_all_points_when_drop_missing_false(tmp_path):
+    # Design path: the sample is fixed, so keep every point -- sampled ones get
+    # their real class, unsampleable ones fall back to their prior map_code.
+    data = np.array([[1, 1], [1, 1]], dtype=np.uint8)
+    p = tmp_path / "clas.tif"
+    _write(p, data, "EPSG:4326", from_origin(0, 2, 1, 1))
+    df = pd.DataFrame({"x": [0.5, 100.0], "y": [1.5, 100.0], "map_code": [0, 0]})
+    out, dropped = extract_map_codes(df, str(p), "x", "y", drop_missing=False)
+    assert dropped == 1  # one point was unsampleable
+    assert len(out) == 2  # but nothing dropped
+    assert out["map_code"].tolist() == [1, 0]  # sampled -> 1, missing -> prior 0
+
+
+def test_drop_missing_false_without_prior_map_code_falls_back_to_zero(tmp_path):
+    data = np.array([[7, 7], [7, 7]], dtype=np.uint8)
+    p = tmp_path / "clas.tif"
+    _write(p, data, "EPSG:4326", from_origin(0, 2, 1, 1))
+    df = pd.DataFrame({"x": [0.5, 100.0], "y": [1.5, 100.0]})  # no map_code column
+    out, dropped = extract_map_codes(df, str(p), "x", "y", drop_missing=False)
+    assert dropped == 1
+    assert out["map_code"].tolist() == [7, 0]  # missing -> 0 when no prior column
+
+
 def test_drops_nodata(tmp_path):
     data = np.array([[5, 255], [5, 5]], dtype=np.uint8)
     p = tmp_path / "clas.tif"

--- a/tests/test_extract_map_codes.py
+++ b/tests/test_extract_map_codes.py
@@ -1,0 +1,78 @@
+import numpy as np
+import pandas as pd
+import rasterio
+from rasterio.transform import from_origin
+
+from component.scripts.geospatial import extract_map_codes
+
+
+def _write(path, data, crs, transform, nodata=None):
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=data.shape[0],
+        width=data.shape[1],
+        count=1,
+        dtype=data.dtype,
+        crs=crs,
+        transform=transform,
+        nodata=nodata,
+    ) as dst:
+        dst.write(data, 1)
+
+
+def test_samples_expected_classes(tmp_path):
+    data = np.array(
+        [[1, 1, 2, 2], [1, 1, 2, 2], [3, 3, 4, 4], [3, 3, 4, 4]], dtype=np.uint8
+    )
+    p = tmp_path / "clas.tif"
+    _write(p, data, "EPSG:4326", from_origin(0, 4, 1, 1))
+    df = pd.DataFrame(
+        {"x": [0.5, 2.5], "y": [3.5, 0.5]}
+    )  # -> data[0][0]=1, data[3][2]=4
+    out, dropped = extract_map_codes(df, str(p), "x", "y")
+    assert dropped == 0
+    assert out["map_code"].tolist() == [1, 4]
+
+
+def test_drops_out_of_bounds(tmp_path):
+    data = np.array([[1, 1], [1, 1]], dtype=np.uint8)
+    p = tmp_path / "clas.tif"
+    _write(p, data, "EPSG:4326", from_origin(0, 2, 1, 1))
+    df = pd.DataFrame({"x": [0.5, 100.0], "y": [1.5, 100.0]})
+    out, dropped = extract_map_codes(df, str(p), "x", "y")
+    assert dropped == 1
+    assert out["map_code"].tolist() == [1]
+
+
+def test_drops_nodata(tmp_path):
+    data = np.array([[5, 255], [5, 5]], dtype=np.uint8)
+    p = tmp_path / "clas.tif"
+    _write(p, data, "EPSG:4326", from_origin(0, 2, 1, 1), nodata=255)
+    df = pd.DataFrame({"x": [1.5], "y": [1.5]})  # -> data[0][1]=255 (nodata)
+    out, dropped = extract_map_codes(df, str(p), "x", "y")
+    assert dropped == 1
+    assert out.empty
+
+
+def test_reprojects_points(tmp_path):
+    # Raster in Web Mercator, placed ~500km from the coordinate origin so a
+    # broken implementation that forgot to reproject (used raw lon/lat as if
+    # already in EPSG:3857 metres) could never land inside the footprint by
+    # coincidence -- only a correct reprojection does. The point below is the
+    # mid-pixel of cell (row0, col0) -- x,y = (500500, 500500) in EPSG:3857 --
+    # converted to EPSG:4326 via the spherical Web Mercator inverse formula
+    # and cross-checked against rasterio.warp.transform's forward transform
+    # (both agree to sub-metre precision; see task-1-report.md for the
+    # derivation). Using the raw (4.496068, 4.491461) directly as metres
+    # would fall far outside the raster's [500000, 502000] x [499000, 501000]
+    # bounds, so a non-reprojecting implementation fails this test (dropped
+    # == 1) rather than passing it by accident.
+    data = np.array([[7, 7], [7, 7]], dtype=np.uint8)
+    p = tmp_path / "merc.tif"
+    _write(p, data, "EPSG:3857", from_origin(500000, 501000, 1000, 1000))
+    df = pd.DataFrame({"x": [4.496068], "y": [4.491461]})
+    out, dropped = extract_map_codes(df, str(p), "x", "y")
+    assert dropped == 0
+    assert out["map_code"].tolist() == [7]

--- a/tests/test_extract_map_codes.py
+++ b/tests/test_extract_map_codes.py
@@ -67,6 +67,16 @@ def test_drops_point_on_right_bottom_edge(tmp_path):
     assert out["map_code"].tolist() == [1]
 
 
+def test_existing_map_code_is_overwritten(tmp_path):
+    data = np.array([[1, 1], [1, 1]], dtype=np.uint8)
+    p = tmp_path / "clas.tif"
+    _write(p, data, "EPSG:4326", from_origin(0, 2, 1, 1))
+    df = pd.DataFrame({"x": [0.5], "y": [1.5], "map_code": [99]})  # bogus pre-existing
+    out, dropped = extract_map_codes(df, str(p), "x", "y")
+    assert dropped == 0
+    assert out["map_code"].tolist() == [1]  # raster value wins, 99 overwritten
+
+
 def test_reprojects_points(tmp_path):
     # Raster in Web Mercator, placed ~500km from the coordinate origin so a
     # broken implementation that forgot to reproject (used raw lon/lat as if

--- a/tests/test_extract_map_codes.py
+++ b/tests/test_extract_map_codes.py
@@ -56,6 +56,17 @@ def test_drops_nodata(tmp_path):
     assert out.empty
 
 
+def test_drops_point_on_right_bottom_edge(tmp_path):
+    data = np.array([[1, 1], [1, 1]], dtype=np.uint8)
+    p = tmp_path / "edge.tif"
+    _write(p, data, "EPSG:4326", from_origin(0, 2, 1, 1))  # bounds x[0,2] y[0,2]
+    # (2.0, 1.0): x == right edge -> maps to col 2 (out of range) -> must be dropped
+    df = pd.DataFrame({"x": [2.0, 0.5], "y": [1.0, 0.5]})
+    out, dropped = extract_map_codes(df, str(p), "x", "y")
+    assert dropped == 1
+    assert out["map_code"].tolist() == [1]
+
+
 def test_reprojects_points(tmp_path):
     # Raster in Web Mercator, placed ~500km from the coordinate origin so a
     # broken implementation that forgot to reproject (used raw lon/lat as if

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,22 @@
+"""quiet_tile_server_logs raises the chatty tile-server loggers to WARNING."""
+
+import logging
+
+from component.scripts.logging_config import _NOISY_LOGGERS, quiet_tile_server_logs
+
+
+def test_quiet_tile_server_logs_sets_warning():
+    saved = {name: logging.getLogger(name).level for name in _NOISY_LOGGERS}
+    try:
+        quiet_tile_server_logs()
+        for name in _NOISY_LOGGERS:
+            assert logging.getLogger(name).level == logging.WARNING, name
+    finally:
+        for name, level in saved.items():
+            logging.getLogger(name).setLevel(level)
+
+
+def test_quiet_tile_server_logs_covers_the_noisy_sources():
+    # The two access-log + debug-log sources seen in the served terminal.
+    assert "uvicorn.access" in _NOISY_LOGGERS
+    assert "VECTORTILES" in _NOISY_LOGGERS

--- a/tests/test_map_sample_points.py
+++ b/tests/test_map_sample_points.py
@@ -9,6 +9,8 @@ from component.widget.map import SbaeMap
 class _FakeMap:
     def __init__(self):
         self.sample_points_layer = None
+        self.reference_points_layer = None
+        self.reference_points_dir = None
         self.added = []
         self.removed = []
 
@@ -36,7 +38,7 @@ def test_build_empty_returns_none():
 def test_build_delegates(monkeypatch):
     called = {}
 
-    def fake_build(df, colors, *, dest_dir):
+    def fake_build(df, colors, *, dest_dir, default_color="#888888"):
         called["colors"] = colors
         return "LAYER"
 
@@ -50,7 +52,7 @@ def test_build_delegates(monkeypatch):
 def test_add_sample_points_error_notifies(monkeypatch):
     from component.model import app_state as real_app_state
 
-    def boom(df, colors, *, dest_dir):
+    def boom(df, colors, *, dest_dir, default_color="#888888"):
         raise VectorTileError("nope")
 
     errs = []
@@ -87,7 +89,7 @@ def test_build_cleans_dir_on_failure(monkeypatch, tmp_path):
         built_dir.mkdir()
         return str(built_dir)
 
-    def boom(df, colors, *, dest_dir):
+    def boom(df, colors, *, dest_dir, default_color="#888888"):
         raise VectorTileError("nope")
 
     monkeypatch.setattr(map_mod.tempfile, "mkdtemp", fake_mkdtemp)
@@ -98,3 +100,38 @@ def test_build_cleans_dir_on_failure(monkeypatch, tmp_path):
         SbaeMap.build_sample_points_layer(_FakeMap(), df, {})
 
     assert not built_dir.exists()  # the just-created dir is not leaked
+
+
+def test_build_sample_points_layer_passes_point_color(monkeypatch):
+    captured = {}
+
+    def fake_build(df, colors, *, dest_dir, default_color="#888888"):
+        captured["default_color"] = default_color
+        return "LAYER"
+
+    monkeypatch.setattr(map_mod, "build_points_pmtiles_layer", fake_build)
+    df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
+    SbaeMap.build_sample_points_layer(_FakeMap(), df, {}, point_color="#ff7f0e")
+    assert captured["default_color"] == "#ff7f0e"
+
+
+def test_add_reference_points_uses_own_layer(monkeypatch):
+    class _Layer:
+        pass
+
+    def fake_build(df, colors, *, dest_dir, default_color="#888888"):
+        layer = _Layer()
+        layer._color = default_color
+        return layer
+
+    monkeypatch.setattr(map_mod, "build_points_pmtiles_layer", fake_build)
+    m = _FakeMap()
+    df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
+    SbaeMap.add_reference_points(m, df, point_color="#ff7f0e")
+
+    # attached under the distinct ref key, tracked apart from the design layer
+    assert m.added and m.added[0][1] == "ref_pts"
+    assert m.reference_points_layer is not None
+    assert m.sample_points_layer is None  # design layer untouched
+    assert m.added[0][0].name == "Reference points"
+    assert m.added[0][0]._color == "#ff7f0e"

--- a/tests/test_map_sample_points.py
+++ b/tests/test_map_sample_points.py
@@ -1,11 +1,9 @@
-import types
-
 import pandas as pd
 import pytest
 
+from component.scripts.vector_tiles import VectorTileError
 from component.widget import map as map_mod
 from component.widget.map import SbaeMap
-from component.scripts.vector_tiles import VectorTileError
 
 
 class _FakeMap:
@@ -63,3 +61,40 @@ def test_add_sample_points_error_notifies(monkeypatch):
     SbaeMap.add_sample_points(m, df)  # must not raise
     assert errs and "Could not render sample points" in errs[0]
     assert m.added == []
+
+
+def test_attach_removes_previous_backing_dir(tmp_path):
+    old_dir = tmp_path / "old"
+    new_dir = tmp_path / "new"
+    old_dir.mkdir()
+    new_dir.mkdir()
+    m = _FakeMap()
+    m.sample_points_layer = "OLD"
+    m.sample_points_dir = str(old_dir)
+    m._pending_points_dir = str(new_dir)
+
+    SbaeMap.attach_sample_points_layer(m, "NEW")
+
+    assert not old_dir.exists()  # previous layer's backing dir is reclaimed
+    assert new_dir.exists()  # the dir backing the now-live layer survives
+    assert m.sample_points_dir == str(new_dir)
+
+
+def test_build_cleans_dir_on_failure(monkeypatch, tmp_path):
+    built_dir = tmp_path / "built"
+
+    def fake_mkdtemp(prefix=""):
+        built_dir.mkdir()
+        return str(built_dir)
+
+    def boom(df, colors, *, dest_dir):
+        raise VectorTileError("nope")
+
+    monkeypatch.setattr(map_mod.tempfile, "mkdtemp", fake_mkdtemp)
+    monkeypatch.setattr(map_mod, "build_points_pmtiles_layer", boom)
+    df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
+
+    with pytest.raises(VectorTileError):
+        SbaeMap.build_sample_points_layer(_FakeMap(), df, {})
+
+    assert not built_dir.exists()  # the just-created dir is not leaked

--- a/tests/test_map_sample_points.py
+++ b/tests/test_map_sample_points.py
@@ -259,6 +259,13 @@ def test_add_reference_points_colors_by_correctness(monkeypatch):
     assert captured["colors"] == {0: map_mod.INCORRECT_COLOR, 1: map_mod.CORRECT_COLOR}
     assert list(captured["df"]["correct"]) == [1, 0, 1]  # agree, disagree, agree
     assert m._reference_evaluated is True
+    # legend published to reactive state for the PointsLegend overlay
+    from component.model import app_state as real_app_state
+
+    assert real_app_state.points_legend.value == {
+        map_mod._CORRECT_LEGEND_LABEL: map_mod.CORRECT_COLOR,
+        map_mod._INCORRECT_LEGEND_LABEL: map_mod.INCORRECT_COLOR,
+    }
 
 
 def test_add_reference_points_neutral_without_map_code(monkeypatch):
@@ -283,3 +290,48 @@ def test_add_reference_points_neutral_without_map_code(monkeypatch):
     assert captured["colors"] == {}
     assert captured["default_color"] == map_mod.REFERENCE_NEUTRAL_COLOR
     assert m._reference_evaluated is False
+    from component.model import app_state as real_app_state
+
+    assert real_app_state.points_legend.value == {
+        map_mod._REFERENCE_LEGEND_LABEL: map_mod.REFERENCE_NEUTRAL_COLOR
+    }
+
+
+def test_add_reference_points_skips_rebuild_when_unchanged(monkeypatch):
+    """Re-submitting identical points must not rebuild (the tab-switch case)."""
+    calls = []
+
+    class _Layer:
+        pass
+
+    async def fake_build(df, colors, *, dest_dir, default_color="#888888", **kwargs):
+        calls.append(1)
+        return _Layer()
+
+    monkeypatch.setattr(map_mod, "build_points_pmtiles_layer", fake_build)
+    m = _FakeMap()
+    df = pd.DataFrame(
+        {
+            "longitude": [1.0, 2.0],
+            "latitude": [1.0, 2.0],
+            "map_code": [1, 2],
+            "ref_code": [1, 3],
+        }
+    )
+    asyncio.run(SbaeMap.add_reference_points(m, df))
+    assert len(calls) == 1
+
+    # same content, different object (a fresh worker build) -> no tippecanoe run
+    asyncio.run(SbaeMap.add_reference_points(m, df.copy()))
+    assert len(calls) == 1
+
+    # changed content -> rebuild
+    df2 = df.copy()
+    df2.loc[0, "ref_code"] = 9
+    asyncio.run(SbaeMap.add_reference_points(m, df2))
+    assert len(calls) == 2
+
+    # clearing resets the signature, so identical data rebuilds afterwards
+    SbaeMap.clear_reference_points(m)
+    asyncio.run(SbaeMap.add_reference_points(m, df.copy()))
+    assert len(calls) == 3

--- a/tests/test_map_sample_points.py
+++ b/tests/test_map_sample_points.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pandas as pd
 import pytest
 
@@ -18,8 +20,8 @@ class _FakeMap:
     def add_layer(self, layer, key=None):
         self.added.append((layer, key))
 
-    def remove_layer(self, layer):
-        self.removed.append(layer)
+    def remove_layer(self, key, base=False, none_ok=False):
+        self.removed.append(key)
 
     def fit_bounds(self, bounds):
         self.fitted = bounds
@@ -53,19 +55,24 @@ def test_attach_skips_zoom_when_layer_has_no_bounds():
 
 
 def test_build_empty_returns_none():
-    assert SbaeMap.build_sample_points_layer(_FakeMap(), pd.DataFrame(), {}) is None
+    layer = asyncio.run(
+        SbaeMap.build_sample_points_layer(_FakeMap(), pd.DataFrame(), {})
+    )
+    assert layer is None
 
 
 def test_build_delegates(monkeypatch):
     called = {}
 
-    def fake_build(df, colors, *, dest_dir, default_color="#888888"):
+    async def fake_build(df, colors, *, dest_dir, default_color="#888888", **kwargs):
         called["colors"] = colors
         return "LAYER"
 
     monkeypatch.setattr(map_mod, "build_points_pmtiles_layer", fake_build)
     df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
-    layer = SbaeMap.build_sample_points_layer(_FakeMap(), df, {3: "#333333"})
+    layer = asyncio.run(
+        SbaeMap.build_sample_points_layer(_FakeMap(), df, {3: "#333333"})
+    )
     assert layer == "LAYER"
     assert called["colors"] == {3: "#333333"}
 
@@ -73,7 +80,7 @@ def test_build_delegates(monkeypatch):
 def test_add_sample_points_error_notifies(monkeypatch):
     from component.model import app_state as real_app_state
 
-    def boom(df, colors, *, dest_dir, default_color="#888888"):
+    async def boom(df, colors, *, dest_dir, default_color="#888888", **kwargs):
         raise VectorTileError("nope")
 
     errs = []
@@ -81,7 +88,7 @@ def test_add_sample_points_error_notifies(monkeypatch):
     monkeypatch.setattr(real_app_state, "add_error", lambda msg: errs.append(msg))
     m = _FakeMap()
     df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
-    SbaeMap.add_sample_points(m, df)  # must not raise
+    asyncio.run(SbaeMap.add_sample_points(m, df))  # must not raise
     assert errs and "Could not render sample points" in errs[0]
     assert m.added == []
 
@@ -110,7 +117,7 @@ def test_build_cleans_dir_on_failure(monkeypatch, tmp_path):
         built_dir.mkdir()
         return str(built_dir)
 
-    def boom(df, colors, *, dest_dir, default_color="#888888"):
+    async def boom(df, colors, *, dest_dir, default_color="#888888", **kwargs):
         raise VectorTileError("nope")
 
     monkeypatch.setattr(map_mod.tempfile, "mkdtemp", fake_mkdtemp)
@@ -118,7 +125,7 @@ def test_build_cleans_dir_on_failure(monkeypatch, tmp_path):
     df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
 
     with pytest.raises(VectorTileError):
-        SbaeMap.build_sample_points_layer(_FakeMap(), df, {})
+        asyncio.run(SbaeMap.build_sample_points_layer(_FakeMap(), df, {}))
 
     assert not built_dir.exists()  # the just-created dir is not leaked
 
@@ -126,33 +133,153 @@ def test_build_cleans_dir_on_failure(monkeypatch, tmp_path):
 def test_build_sample_points_layer_passes_point_color(monkeypatch):
     captured = {}
 
-    def fake_build(df, colors, *, dest_dir, default_color="#888888"):
+    async def fake_build(df, colors, *, dest_dir, default_color="#888888", **kwargs):
         captured["default_color"] = default_color
         return "LAYER"
 
     monkeypatch.setattr(map_mod, "build_points_pmtiles_layer", fake_build)
     df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
-    SbaeMap.build_sample_points_layer(_FakeMap(), df, {}, point_color="#ff7f0e")
+    asyncio.run(
+        SbaeMap.build_sample_points_layer(_FakeMap(), df, {}, point_color="#ff7f0e")
+    )
     assert captured["default_color"] == "#ff7f0e"
 
 
-def test_add_reference_points_uses_own_layer(monkeypatch):
+def test_build_sample_points_layer_rides_overlay_pane(monkeypatch):
     class _Layer:
         pass
 
-    def fake_build(df, colors, *, dest_dir, default_color="#888888"):
-        layer = _Layer()
-        layer._color = default_color
-        return layer
+    async def fake_build(df, colors, *, dest_dir, default_color="#888888", **kwargs):
+        return _Layer()
+
+    monkeypatch.setattr(map_mod, "build_points_pmtiles_layer", fake_build)
+    df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
+    layer = asyncio.run(SbaeMap.build_sample_points_layer(_FakeMap(), df, {}))
+    # points go in leaflet's overlayPane (z 400) so a raster added later --
+    # a GridLayer in the tilePane (z 200) -- can never cover them
+    assert layer.pane == "overlayPane"
+
+
+def test_clear_reference_points_removes_layer(tmp_path):
+    ref_dir = tmp_path / "ref"
+    ref_dir.mkdir()
+    m = _FakeMap()
+    m.reference_points_layer = "REF"
+    m.reference_points_dir = str(ref_dir)
+
+    SbaeMap.clear_reference_points(m)
+
+    assert m.removed == ["ref_pts"]  # removed by stable key, not the tracked object
+    assert m.reference_points_layer is None
+    assert m.reference_points_dir is None
+    assert not ref_dir.exists()  # its backing dir is reclaimed
+
+
+def test_clear_reference_points_tolerates_layer_already_gone():
+    """Clearing tolerates a reference layer already gone from the shared map.
+
+    Reproduces the live crash: the map can drop the reference layer out from
+    under the tracker (theme change / re-style swaps the widget), so pysepal's
+    ``remove_layer`` raises for the stale handle. Clearing must use key-based
+    removal with ``none_ok`` so it never propagates that error.
+    """
+
+    class _StrictMap:
+        def __init__(self):
+            self.reference_points_layer = "STALE"  # tracked, but not on the map
+            self.reference_points_dir = None
+            self.removed = []
+
+        def remove_layer(self, key, base=False, none_ok=False):
+            if not none_ok:
+                raise ValueError(f"no layer corresponding to {key} on the map")
+            self.removed.append(key)
+
+    m = _StrictMap()
+    SbaeMap.clear_reference_points(m)  # must not raise
+    assert m.reference_points_layer is None
+    assert m.removed == ["ref_pts"]
+
+
+def test_compose_points_legend():
+    compose = map_mod._compose_points_legend
+    assert compose(False, False, False) == {}
+    assert compose(True, False, False) == {
+        map_mod._SAMPLE_LEGEND_LABEL: map_mod.SAMPLE_POINT_COLOR
+    }
+    # reference evaluated -> green/red correctness key
+    assert compose(False, True, True) == {
+        map_mod._CORRECT_LEGEND_LABEL: map_mod.CORRECT_COLOR,
+        map_mod._INCORRECT_LEGEND_LABEL: map_mod.INCORRECT_COLOR,
+    }
+    # reference not yet evaluated -> single neutral entry
+    assert compose(False, True, False) == {
+        map_mod._REFERENCE_LEGEND_LABEL: map_mod.REFERENCE_NEUTRAL_COLOR
+    }
+    # both layers -> sample + correctness
+    assert set(compose(True, True, True)) == {
+        map_mod._SAMPLE_LEGEND_LABEL,
+        map_mod._CORRECT_LEGEND_LABEL,
+        map_mod._INCORRECT_LEGEND_LABEL,
+    }
+
+
+def test_add_reference_points_colors_by_correctness(monkeypatch):
+    captured = {}
+
+    class _Layer:
+        pass
+
+    async def fake_build(df, colors, *, dest_dir, default_color="#888888", **kwargs):
+        captured["colors"] = colors
+        captured["kwargs"] = kwargs
+        captured["df"] = df
+        return _Layer()
 
     monkeypatch.setattr(map_mod, "build_points_pmtiles_layer", fake_build)
     m = _FakeMap()
-    df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
-    SbaeMap.add_reference_points(m, df, point_color="#ff7f0e")
+    df = pd.DataFrame(
+        {
+            "longitude": [1.0, 2.0, 3.0],
+            "latitude": [1.0, 2.0, 3.0],
+            "map_code": [1, 2, 5],
+            "ref_code": [1, 3, 5],  # row 2 disagrees -> incorrect
+        }
+    )
+    asyncio.run(SbaeMap.add_reference_points(m, df))
 
     # attached under the distinct ref key, tracked apart from the design layer
     assert m.added and m.added[0][1] == "ref_pts"
     assert m.reference_points_layer is not None
     assert m.sample_points_layer is None  # design layer untouched
     assert m.added[0][0].name == "Reference points"
-    assert m.added[0][0]._color == "#ff7f0e"
+    # coloured by agreement only: correct=green(1), incorrect=red(0)
+    assert captured["kwargs"]["color_field"] == "correct"
+    assert captured["kwargs"]["radius"] == 6
+    assert captured["colors"] == {0: map_mod.INCORRECT_COLOR, 1: map_mod.CORRECT_COLOR}
+    assert list(captured["df"]["correct"]) == [1, 0, 1]  # agree, disagree, agree
+    assert m._reference_evaluated is True
+
+
+def test_add_reference_points_neutral_without_map_code(monkeypatch):
+    captured = {}
+
+    class _Layer:
+        pass
+
+    async def fake_build(df, colors, *, dest_dir, default_color="#888888", **kwargs):
+        captured["colors"] = colors
+        captured["kwargs"] = kwargs
+        captured["default_color"] = default_color
+        return _Layer()
+
+    monkeypatch.setattr(map_mod, "build_points_pmtiles_layer", fake_build)
+    m = _FakeMap()
+    # no map_code -> correctness unknown (e.g. raster not sampled yet)
+    df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "ref_code": [3]})
+    asyncio.run(SbaeMap.add_reference_points(m, df))
+
+    # single neutral colour, not green/red
+    assert captured["colors"] == {}
+    assert captured["default_color"] == map_mod.REFERENCE_NEUTRAL_COLOR
+    assert m._reference_evaluated is False

--- a/tests/test_map_sample_points.py
+++ b/tests/test_map_sample_points.py
@@ -1,0 +1,65 @@
+import types
+
+import pandas as pd
+import pytest
+
+from component.widget import map as map_mod
+from component.widget.map import SbaeMap
+from component.scripts.vector_tiles import VectorTileError
+
+
+class _FakeMap:
+    def __init__(self):
+        self.sample_points_layer = None
+        self.added = []
+        self.removed = []
+
+    def add_layer(self, layer, key=None):
+        self.added.append((layer, key))
+
+    def remove_layer(self, layer):
+        self.removed.append(layer)
+
+
+def test_attach_swaps_layer():
+    m = _FakeMap()
+    SbaeMap.attach_sample_points_layer(m, "L1")
+    assert m.added == [("L1", "sample_pts")]
+    assert m.sample_points_layer == "L1"
+    SbaeMap.attach_sample_points_layer(m, "L2")
+    assert m.removed == ["L1"]
+    assert m.sample_points_layer == "L2"
+
+
+def test_build_empty_returns_none():
+    assert SbaeMap.build_sample_points_layer(_FakeMap(), pd.DataFrame(), {}) is None
+
+
+def test_build_delegates(monkeypatch):
+    called = {}
+
+    def fake_build(df, colors, *, dest_dir):
+        called["colors"] = colors
+        return "LAYER"
+
+    monkeypatch.setattr(map_mod, "build_points_pmtiles_layer", fake_build)
+    df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
+    layer = SbaeMap.build_sample_points_layer(_FakeMap(), df, {3: "#333333"})
+    assert layer == "LAYER"
+    assert called["colors"] == {3: "#333333"}
+
+
+def test_add_sample_points_error_notifies(monkeypatch):
+    from component.model import app_state as real_app_state
+
+    def boom(df, colors, *, dest_dir):
+        raise VectorTileError("nope")
+
+    errs = []
+    monkeypatch.setattr(map_mod, "build_points_pmtiles_layer", boom)
+    monkeypatch.setattr(real_app_state, "add_error", lambda msg: errs.append(msg))
+    m = _FakeMap()
+    df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
+    SbaeMap.add_sample_points(m, df)  # must not raise
+    assert errs and "Could not render sample points" in errs[0]
+    assert m.added == []

--- a/tests/test_map_sample_points.py
+++ b/tests/test_map_sample_points.py
@@ -13,12 +13,21 @@ class _FakeMap:
         self.reference_points_dir = None
         self.added = []
         self.removed = []
+        self.fitted = None
 
     def add_layer(self, layer, key=None):
         self.added.append((layer, key))
 
     def remove_layer(self, layer):
         self.removed.append(layer)
+
+    def fit_bounds(self, bounds):
+        self.fitted = bounds
+
+
+class _BoundedLayer:
+    def __init__(self):
+        self.bounds = [[0.0, 0.0], [1.0, 2.0]]
 
 
 def test_attach_swaps_layer():
@@ -29,6 +38,18 @@ def test_attach_swaps_layer():
     SbaeMap.attach_sample_points_layer(m, "L2")
     assert m.removed == ["L1"]
     assert m.sample_points_layer == "L2"
+
+
+def test_attach_zooms_to_layer_bounds():
+    m = _FakeMap()
+    SbaeMap.attach_sample_points_layer(m, _BoundedLayer())
+    assert m.fitted == [[0.0, 0.0], [1.0, 2.0]]  # auto-zoomed to the points
+
+
+def test_attach_skips_zoom_when_layer_has_no_bounds():
+    m = _FakeMap()
+    SbaeMap.attach_sample_points_layer(m, "L1")  # a bounds-less layer double
+    assert m.fitted is None  # view left untouched
 
 
 def test_build_empty_returns_none():

--- a/tests/test_palette.py
+++ b/tests/test_palette.py
@@ -1,0 +1,20 @@
+"""palette_for_codes: a stable categorical palette for class codes."""
+
+from component.scripts.geospatial import palette_for_codes
+
+
+def test_palette_for_codes_stable_regardless_of_input_order():
+    assert palette_for_codes([3, 1, 2]) == palette_for_codes([1, 2, 3])
+
+
+def test_palette_for_codes_distinct_within_base_length():
+    p = palette_for_codes([1, 2, 3])
+    assert len({p[1], p[2], p[3]}) == 3
+    assert all(c.startswith("#") for c in p.values())
+
+
+def test_palette_for_codes_cycles_when_exhausted():
+    p = palette_for_codes(list(range(20)))
+    assert len(p) == 20
+    # the base palette has 9 colours, so the 10th sorted code wraps to the 1st
+    assert p[0] == p[9]

--- a/tests/test_tile_loopback_bridge.py
+++ b/tests/test_tile_loopback_bridge.py
@@ -1,0 +1,51 @@
+"""The tile comm-bridge mount enables jupyter_loopback when flagged.
+
+``_TileLoopbackBridge`` mounts jupyter_loopback's anywidget comm bridge so
+localtileserver's ``http://127.0.0.1:<port>`` tile URLs reach the browser when
+the app is served behind a reverse proxy (``run-solara --serve`` / SEPAL). It is
+gated on ``LOCALTILESERVER_COMM_BRIDGE`` so plain local runs keep direct-HTTP
+tiles. This is a Python-side smoke test: it confirms the component renders and
+enables the bridge when the flag is set (the actual browser interception is only
+observable in a live frontend).
+
+Runs in a subprocess (like ``test_app_page_render``) because enabling the bridge
+and rendering under a Solara kernel context mutate process-global singletons.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_RENDER_SCRIPT = """
+import os
+os.environ["LOCALTILESERVER_COMM_BRIDGE"] = "1"
+
+import solara
+import solara.server.kernel_context as kc
+from sepal_ui.solara import setup_sessions
+
+ctx = kc.create_dummy_context()
+kc.set_current_context(ctx)
+setup_sessions()
+
+import app
+import jupyter_loopback as jl
+
+solara.render(app._TileLoopbackBridge(), handle_error=False)
+assert jl.is_comm_bridge_enabled(), "comm bridge was not enabled with the flag set"
+print("BRIDGE_OK")
+"""
+
+
+def test_bridge_enables_when_flagged():
+    result = subprocess.run(
+        [sys.executable, "-c", _RENDER_SCRIPT],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr[-3000:]
+    assert "BRIDGE_OK" in result.stdout

--- a/tests/test_vector_tiles.py
+++ b/tests/test_vector_tiles.py
@@ -104,6 +104,22 @@ def test_build_points_layer_client_error_wrapped(tmp_path):
         build_points_pmtiles_layer(df, {}, dest_dir=str(tmp_path), client_factory=boom)
 
 
+def test_build_points_layer_geojson_serialization_error_wrapped(tmp_path):
+    # All-integer columns (including lon/lat) so iterrows() keeps the row dtype
+    # int64 instead of upcasting to float64 -- that upcast is what makes
+    # np.int64 JSON-serializable (it becomes a plain float subtype), so it
+    # would silently hide the bug this test guards against.
+    df = pd.DataFrame({"longitude": [1], "latitude": [2], "class_id": [7]})
+    with pytest.raises(VectorTileError):
+        build_points_pmtiles_layer(
+            df,
+            {7: "#333333"},
+            dest_dir=str(tmp_path),
+            color_field="class_id",
+            client_factory=lambda **k: _FakeClient(**k),
+        )
+
+
 @pytest.mark.skipif(
     __import__("shutil").which("tippecanoe") is None, reason="tippecanoe not installed"
 )

--- a/tests/test_vector_tiles.py
+++ b/tests/test_vector_tiles.py
@@ -136,3 +136,37 @@ def test_build_points_layer_real(tmp_path):
     except VectorTileError as e:
         pytest.skip(f"tile library unavailable: {e}")
     assert layer is not None
+
+
+from component.scripts.vector_tiles import build_layer_or_notify
+
+
+class _MapOK:
+    def build_sample_points_layer(self, df, colors):
+        return "LAYER"
+
+
+class _MapBoom:
+    def build_sample_points_layer(self, df, colors):
+        raise VectorTileError("bad raster")
+
+
+def test_build_layer_or_notify_success():
+    df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
+    assert build_layer_or_notify(_MapOK(), df, {3: "#333333"}) == "LAYER"
+
+
+def test_build_layer_or_notify_none_map_or_empty():
+    df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0]})
+    assert build_layer_or_notify(None, df, {}) is None
+    assert build_layer_or_notify(_MapOK(), pd.DataFrame(), {}) is None
+
+
+def test_build_layer_or_notify_failure_notifies(monkeypatch):
+    from component.model import app_state as real_app_state
+
+    errs = []
+    monkeypatch.setattr(real_app_state, "add_error", lambda msg: errs.append(msg))
+    df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
+    assert build_layer_or_notify(_MapBoom(), df, {}) is None
+    assert errs and "Could not render sample points" in errs[0]

--- a/tests/test_vector_tiles.py
+++ b/tests/test_vector_tiles.py
@@ -4,6 +4,7 @@ import pytest
 from component.scripts.vector_tiles import (
     POINT_CONVERSION_OPTIONS,
     VectorTileError,
+    build_layer_or_notify,
     build_point_style,
     build_points_pmtiles_layer,
     points_to_geojson,
@@ -52,56 +53,49 @@ def test_build_point_style_empty_colors_plain_default():
     assert style["layers"][0]["paint"]["circle-color"] == "#abcdef"
 
 
-class _FakeClient:
-    def __init__(self, **kwargs):
-        self.kwargs = kwargs
-        self.pmtiles_url = "http://localhost:1/pmtiles?filePath=p.pmtiles"
-
-    def list_layers(self):
-        return ["sample_points"]
-
-    def create_leaflet_layer(self, style=None):
-        return {"layer": True, "style": style}
-
-
 def test_build_points_layer_writes_geojson_and_passes_style(tmp_path):
     df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
     captured = {}
 
-    def factory(**kwargs):
-        captured["kwargs"] = kwargs
-        return _FakeClient(**kwargs)
+    def factory(source, *, style, conversion_options, allowed_directories):
+        captured["conversion_options"] = conversion_options
+        captured["allowed_directories"] = allowed_directories
+        # ``style`` is a builder; resolve it with fake archive metadata + URL.
+        metadata = {"vector_layers": [{"id": "sample_points"}]}
+        resolved = style(metadata, "http://localhost:1/pmtiles?filePath=p.pmtiles")
+        return {"layer": True, "style": resolved, "bounds": [[0.0, 0.0], [1.0, 1.0]]}
 
     layer = build_points_pmtiles_layer(
-        df, {3: "#333333"}, dest_dir=str(tmp_path), client_factory=factory
+        df, {3: "#333333"}, dest_dir=str(tmp_path), layer_factory=factory
     )
     assert (tmp_path / "sample_points.geojson").exists()
-    assert captured["kwargs"]["conversion_options"] == POINT_CONVERSION_OPTIONS
-    assert captured["kwargs"]["allowed_directories"] == [str(tmp_path)]
+    assert captured["conversion_options"] == POINT_CONVERSION_OPTIONS
+    assert captured["allowed_directories"] == [str(tmp_path)]
     style = layer["style"]
     assert style["layers"][0]["source-layer"] == "sample_points"
     assert style["layers"][0]["paint"]["circle-color"][2:] == [3, "#333333", "#888888"]
+    assert layer["bounds"] == [[0.0, 0.0], [1.0, 1.0]]
 
 
 def test_build_points_layer_no_layers_raises(tmp_path):
-    class _NoLayers(_FakeClient):
-        def list_layers(self):
-            return []
+    def factory(source, *, style, conversion_options, allowed_directories):
+        # Empty archive metadata -> the style builder must raise.
+        return {"style": style({"vector_layers": []}, "u")}
 
     df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
     with pytest.raises(VectorTileError):
         build_points_pmtiles_layer(
-            df, {}, dest_dir=str(tmp_path), client_factory=lambda **k: _NoLayers(**k)
+            df, {}, dest_dir=str(tmp_path), layer_factory=factory
         )
 
 
-def test_build_points_layer_client_error_wrapped(tmp_path):
-    def boom(**k):
+def test_build_points_layer_open_error_wrapped(tmp_path):
+    def boom(source, *, style, conversion_options, allowed_directories):
         raise RuntimeError("tippecanoe missing")
 
     df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
     with pytest.raises(VectorTileError):
-        build_points_pmtiles_layer(df, {}, dest_dir=str(tmp_path), client_factory=boom)
+        build_points_pmtiles_layer(df, {}, dest_dir=str(tmp_path), layer_factory=boom)
 
 
 def test_build_points_layer_geojson_serialization_error_wrapped(tmp_path):
@@ -116,7 +110,7 @@ def test_build_points_layer_geojson_serialization_error_wrapped(tmp_path):
             {7: "#333333"},
             dest_dir=str(tmp_path),
             color_field="class_id",
-            client_factory=lambda **k: _FakeClient(**k),
+            layer_factory=lambda source, **k: {"layer": True},
         )
 
 
@@ -136,9 +130,6 @@ def test_build_points_layer_real(tmp_path):
     except VectorTileError as e:
         pytest.skip(f"tile library unavailable: {e}")
     assert layer is not None
-
-
-from component.scripts.vector_tiles import build_layer_or_notify
 
 
 class _MapOK:

--- a/tests/test_vector_tiles.py
+++ b/tests/test_vector_tiles.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from component.scripts.vector_tiles import points_to_geojson
+from component.scripts.vector_tiles import build_point_style, points_to_geojson
 
 
 def test_points_to_geojson_shape_and_lonlat_order():
@@ -26,3 +26,20 @@ def test_points_to_geojson_omits_absent_props():
 def test_points_to_geojson_empty_df():
     fc = points_to_geojson(pd.DataFrame({"longitude": [], "latitude": []}))
     assert fc["features"] == []
+
+
+def test_build_point_style_categorized_match():
+    style = build_point_style("http://x/p", {1: "#111111", 2: "#222222"}, "pts")
+    assert style["sources"]["pmtiles_source"]["url"] == "pmtiles://http://x/p"
+    layer = style["layers"][0]
+    assert layer["type"] == "circle"
+    assert layer["source-layer"] == "pts"
+    cc = layer["paint"]["circle-color"]
+    assert cc[0] == "match"
+    assert cc[1] == ["get", "map_code"]
+    assert cc[2:] == [1, "#111111", 2, "#222222", "#888888"]  # ...default last
+
+
+def test_build_point_style_empty_colors_plain_default():
+    style = build_point_style("u", {}, "pts", default_color="#abcdef")
+    assert style["layers"][0]["paint"]["circle-color"] == "#abcdef"

--- a/tests/test_vector_tiles.py
+++ b/tests/test_vector_tiles.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pandas as pd
 import pytest
 
@@ -25,6 +27,17 @@ def test_points_to_geojson_shape_and_lonlat_order():
     assert isinstance(f0["properties"]["map_code"], int)
 
 
+def test_points_to_geojson_emits_multiple_code_props():
+    df = pd.DataFrame(
+        {"longitude": [1.0], "latitude": [2.0], "map_code": [3], "ref_code": [4]}
+    )
+    props = points_to_geojson(df, props=("map_code", "ref_code"))["features"][0][
+        "properties"
+    ]
+    assert props["map_code"] == 3 and isinstance(props["map_code"], int)
+    assert props["ref_code"] == 4 and isinstance(props["ref_code"], int)
+
+
 def test_points_to_geojson_omits_absent_props():
     df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0]})  # no map_code
     fc = points_to_geojson(df)
@@ -36,28 +49,61 @@ def test_points_to_geojson_empty_df():
     assert fc["features"] == []
 
 
-def test_build_point_style_categorized_match():
-    style = build_point_style("http://x/p", {1: "#111111", 2: "#222222"}, "pts")
+def test_build_point_style_emits_flat_layer_per_class():
+    # protomaps-leaflet (the PMTiles renderer) can't evaluate MapLibre colour
+    # expressions, so each class becomes its own flat-coloured, filtered circle
+    # layer rather than one layer with a ["match", ...] circle-color.
+    style = build_point_style(
+        "http://x/p", {1: "#111111", 2: "#222222"}, "pts", categories=[1, 2]
+    )
     assert style["sources"]["pmtiles_source"]["url"] == "pmtiles://http://x/p"
-    layer = style["layers"][0]
-    assert layer["type"] == "circle"
-    assert layer["source-layer"] == "pts"
-    cc = layer["paint"]["circle-color"]
-    assert cc[0] == "match"
-    assert cc[1] == ["get", "map_code"]
-    assert cc[2:] == [1, "#111111", 2, "#222222", "#888888"]  # ...default last
+    layers = style["layers"]
+    assert [layer["type"] for layer in layers] == ["circle", "circle"]
+    assert all(layer["source-layer"] == "pts" for layer in layers)
+    # flat string colours (never an expression array), each behind a == filter
+    assert all(isinstance(layer["paint"]["circle-color"], str) for layer in layers)
+    by_color = {layer["paint"]["circle-color"]: layer for layer in layers}
+    assert by_color["#111111"]["filter"] == ["==", "map_code", 1]
+    assert by_color["#222222"]["filter"] == ["==", "map_code", 2]
 
 
-def test_build_point_style_empty_colors_plain_default():
+def test_build_point_style_empty_colors_single_flat_layer():
     style = build_point_style("u", {}, "pts", default_color="#abcdef")
-    assert style["layers"][0]["paint"]["circle-color"] == "#abcdef"
+    (layer,) = style["layers"]
+    assert layer["paint"]["circle-color"] == "#abcdef"
+    assert "filter" not in layer  # nothing to filter on -- one plain layer
+
+
+def test_build_point_style_greenred_by_correctness():
+    # Analysis colours by agreement only: correct=green, incorrect=red, one flat
+    # filtered layer each -- no per-class palette.
+    style = build_point_style(
+        "u",
+        {0: "#c62828", 1: "#2e7d32"},
+        "pts",
+        color_field="correct",
+        categories=[0, 1],
+    )
+    by_color = {
+        layer["paint"]["circle-color"]: layer["filter"] for layer in style["layers"]
+    }
+    assert by_color["#2e7d32"] == ["==", "correct", 1]  # correct -> green
+    assert by_color["#c62828"] == ["==", "correct", 0]  # incorrect -> red
+
+
+def test_build_point_style_uniform_ring_colour():
+    # The ring (halo) is always a plain fixed colour.
+    style = build_point_style(
+        "u", {1: "#111111"}, "pts", categories=[1], stroke_color="#ffffff"
+    )
+    assert style["layers"][0]["paint"]["circle-stroke-color"] == "#ffffff"
 
 
 def test_build_points_layer_writes_geojson_and_passes_style(tmp_path):
     df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
     captured = {}
 
-    def factory(source, *, style, conversion_options, allowed_directories):
+    async def factory(source, *, style, conversion_options, allowed_directories):
         captured["conversion_options"] = conversion_options
         captured["allowed_directories"] = allowed_directories
         # ``style`` is a builder; resolve it with fake archive metadata + URL.
@@ -65,37 +111,83 @@ def test_build_points_layer_writes_geojson_and_passes_style(tmp_path):
         resolved = style(metadata, "http://localhost:1/pmtiles?filePath=p.pmtiles")
         return {"layer": True, "style": resolved, "bounds": [[0.0, 0.0], [1.0, 1.0]]}
 
-    layer = build_points_pmtiles_layer(
-        df, {3: "#333333"}, dest_dir=str(tmp_path), layer_factory=factory
+    layer = asyncio.run(
+        build_points_pmtiles_layer(
+            df, {3: "#333333"}, dest_dir=str(tmp_path), layer_factory=factory
+        )
     )
     assert (tmp_path / "sample_points.geojson").exists()
     assert captured["conversion_options"] == POINT_CONVERSION_OPTIONS
     assert captured["allowed_directories"] == [str(tmp_path)]
     style = layer["style"]
-    assert style["layers"][0]["source-layer"] == "sample_points"
-    assert style["layers"][0]["paint"]["circle-color"][2:] == [3, "#333333", "#888888"]
+    circle = style["layers"][0]
+    assert circle["source-layer"] == "sample_points"
+    # per-class flat layer, filtered on the observed map code (no colour expr)
+    assert circle["paint"]["circle-color"] == "#333333"
+    assert circle["filter"] == ["==", "map_code", 3]
     assert layer["bounds"] == [[0.0, 0.0], [1.0, 1.0]]
 
 
+def test_build_points_layer_categorizes_by_color_field(tmp_path):
+    import json
+
+    # Analysis path: colour by a derived "correct" field -> per-value flat layers.
+    df = pd.DataFrame(
+        {"longitude": [1.0, 2.0], "latitude": [2.0, 3.0], "correct": [1, 0]}
+    )
+    captured = {}
+
+    async def factory(source, *, style, conversion_options, allowed_directories):
+        metadata = {"vector_layers": [{"id": "sample_points"}]}
+        captured["style"] = style(metadata, "http://x/pmtiles")
+        return {"style": captured["style"]}
+
+    asyncio.run(
+        build_points_pmtiles_layer(
+            df,
+            {0: "#c62828", 1: "#2e7d32"},
+            dest_dir=str(tmp_path),
+            color_field="correct",
+            radius=6,
+            layer_factory=factory,
+        )
+    )
+    fc = json.load(open(tmp_path / "sample_points.geojson"))
+    # the colour field must ride along in the tile features (the == filter needs it)
+    assert "correct" in fc["features"][0]["properties"]
+    by_color = {
+        layer["paint"]["circle-color"]: layer["filter"]
+        for layer in captured["style"]["layers"]
+    }
+    assert by_color["#2e7d32"] == ["==", "correct", 1]
+    assert by_color["#c62828"] == ["==", "correct", 0]
+
+
 def test_build_points_layer_no_layers_raises(tmp_path):
-    def factory(source, *, style, conversion_options, allowed_directories):
+    async def factory(source, *, style, conversion_options, allowed_directories):
         # Empty archive metadata -> the style builder must raise.
         return {"style": style({"vector_layers": []}, "u")}
 
     df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
     with pytest.raises(VectorTileError):
-        build_points_pmtiles_layer(
-            df, {}, dest_dir=str(tmp_path), layer_factory=factory
+        asyncio.run(
+            build_points_pmtiles_layer(
+                df, {}, dest_dir=str(tmp_path), layer_factory=factory
+            )
         )
 
 
 def test_build_points_layer_open_error_wrapped(tmp_path):
-    def boom(source, *, style, conversion_options, allowed_directories):
+    async def boom(source, *, style, conversion_options, allowed_directories):
         raise RuntimeError("tippecanoe missing")
 
     df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
     with pytest.raises(VectorTileError):
-        build_points_pmtiles_layer(df, {}, dest_dir=str(tmp_path), layer_factory=boom)
+        asyncio.run(
+            build_points_pmtiles_layer(
+                df, {}, dest_dir=str(tmp_path), layer_factory=boom
+            )
+        )
 
 
 def test_build_points_layer_geojson_serialization_error_wrapped(tmp_path):
@@ -104,13 +196,19 @@ def test_build_points_layer_geojson_serialization_error_wrapped(tmp_path):
     # np.int64 JSON-serializable (it becomes a plain float subtype), so it
     # would silently hide the bug this test guards against.
     df = pd.DataFrame({"longitude": [1], "latitude": [2], "class_id": [7]})
+
+    async def unused_factory(source, **kwargs):
+        return {"layer": True}
+
     with pytest.raises(VectorTileError):
-        build_points_pmtiles_layer(
-            df,
-            {7: "#333333"},
-            dest_dir=str(tmp_path),
-            color_field="class_id",
-            layer_factory=lambda source, **k: {"layer": True},
+        asyncio.run(
+            build_points_pmtiles_layer(
+                df,
+                {7: "#333333"},
+                dest_dir=str(tmp_path),
+                color_field="class_id",
+                layer_factory=unused_factory,
+            )
         )
 
 
@@ -126,31 +224,33 @@ def test_build_points_layer_real(tmp_path):
         }
     )
     try:
-        layer = build_points_pmtiles_layer(df, {1: "#111111"}, dest_dir=str(tmp_path))
+        layer = asyncio.run(
+            build_points_pmtiles_layer(df, {1: "#111111"}, dest_dir=str(tmp_path))
+        )
     except VectorTileError as e:
         pytest.skip(f"tile library unavailable: {e}")
     assert layer is not None
 
 
 class _MapOK:
-    def build_sample_points_layer(self, df, colors):
+    async def build_sample_points_layer(self, df, *args, **kwargs):
         return "LAYER"
 
 
 class _MapBoom:
-    def build_sample_points_layer(self, df, colors):
+    async def build_sample_points_layer(self, df, *args, **kwargs):
         raise VectorTileError("bad raster")
 
 
 def test_build_layer_or_notify_success():
     df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
-    assert build_layer_or_notify(_MapOK(), df, {3: "#333333"}) == "LAYER"
+    assert asyncio.run(build_layer_or_notify(_MapOK(), df)) == "LAYER"
 
 
 def test_build_layer_or_notify_none_map_or_empty():
     df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0]})
-    assert build_layer_or_notify(None, df, {}) is None
-    assert build_layer_or_notify(_MapOK(), pd.DataFrame(), {}) is None
+    assert asyncio.run(build_layer_or_notify(None, df)) is None
+    assert asyncio.run(build_layer_or_notify(_MapOK(), pd.DataFrame())) is None
 
 
 def test_build_layer_or_notify_failure_notifies(monkeypatch):
@@ -159,12 +259,12 @@ def test_build_layer_or_notify_failure_notifies(monkeypatch):
     errs = []
     monkeypatch.setattr(real_app_state, "add_error", lambda msg: errs.append(msg))
     df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
-    assert build_layer_or_notify(_MapBoom(), df, {}) is None
+    assert asyncio.run(build_layer_or_notify(_MapBoom(), df)) is None
     assert errs and "Could not render sample points" in errs[0]
 
 
 class _MapNonVectorTileBoom:
-    def build_sample_points_layer(self, df, colors):
+    async def build_sample_points_layer(self, df, *args, **kwargs):
         # e.g. tempfile.mkdtemp() failing with a raw OSError (disk full /
         # quota) before build_points_pmtiles_layer -- and its VectorTileError
         # wrapping -- is ever reached.
@@ -177,5 +277,5 @@ def test_build_layer_or_notify_non_vector_tile_error_notifies(monkeypatch):
     errs = []
     monkeypatch.setattr(real_app_state, "add_error", lambda msg: errs.append(msg))
     df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
-    assert build_layer_or_notify(_MapNonVectorTileBoom(), df, {}) is None
+    assert asyncio.run(build_layer_or_notify(_MapNonVectorTileBoom(), df)) is None
     assert errs and "Could not render sample points" in errs[0]

--- a/tests/test_vector_tiles.py
+++ b/tests/test_vector_tiles.py
@@ -1,0 +1,28 @@
+import pandas as pd
+
+from component.scripts.vector_tiles import points_to_geojson
+
+
+def test_points_to_geojson_shape_and_lonlat_order():
+    df = pd.DataFrame(
+        {"longitude": [10.0, 11.0], "latitude": [-5.0, -6.0], "map_code": [1, 2]}
+    )
+    fc = points_to_geojson(df)
+    assert fc["type"] == "FeatureCollection"
+    assert len(fc["features"]) == 2
+    f0 = fc["features"][0]
+    assert f0["geometry"]["type"] == "Point"
+    assert f0["geometry"]["coordinates"] == [10.0, -5.0]  # [lon, lat]
+    assert f0["properties"]["map_code"] == 1
+    assert isinstance(f0["properties"]["map_code"], int)
+
+
+def test_points_to_geojson_omits_absent_props():
+    df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0]})  # no map_code
+    fc = points_to_geojson(df)
+    assert fc["features"][0]["properties"] == {}
+
+
+def test_points_to_geojson_empty_df():
+    fc = points_to_geojson(pd.DataFrame({"longitude": [], "latitude": []}))
+    assert fc["features"] == []

--- a/tests/test_vector_tiles.py
+++ b/tests/test_vector_tiles.py
@@ -1,6 +1,13 @@
 import pandas as pd
+import pytest
 
-from component.scripts.vector_tiles import build_point_style, points_to_geojson
+from component.scripts.vector_tiles import (
+    POINT_CONVERSION_OPTIONS,
+    VectorTileError,
+    build_point_style,
+    build_points_pmtiles_layer,
+    points_to_geojson,
+)
 
 
 def test_points_to_geojson_shape_and_lonlat_order():
@@ -43,3 +50,73 @@ def test_build_point_style_categorized_match():
 def test_build_point_style_empty_colors_plain_default():
     style = build_point_style("u", {}, "pts", default_color="#abcdef")
     assert style["layers"][0]["paint"]["circle-color"] == "#abcdef"
+
+
+class _FakeClient:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.pmtiles_url = "http://localhost:1/pmtiles?filePath=p.pmtiles"
+
+    def list_layers(self):
+        return ["sample_points"]
+
+    def create_leaflet_layer(self, style=None):
+        return {"layer": True, "style": style}
+
+
+def test_build_points_layer_writes_geojson_and_passes_style(tmp_path):
+    df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
+    captured = {}
+
+    def factory(**kwargs):
+        captured["kwargs"] = kwargs
+        return _FakeClient(**kwargs)
+
+    layer = build_points_pmtiles_layer(
+        df, {3: "#333333"}, dest_dir=str(tmp_path), client_factory=factory
+    )
+    assert (tmp_path / "sample_points.geojson").exists()
+    assert captured["kwargs"]["conversion_options"] == POINT_CONVERSION_OPTIONS
+    assert captured["kwargs"]["allowed_directories"] == [str(tmp_path)]
+    style = layer["style"]
+    assert style["layers"][0]["source-layer"] == "sample_points"
+    assert style["layers"][0]["paint"]["circle-color"][2:] == [3, "#333333", "#888888"]
+
+
+def test_build_points_layer_no_layers_raises(tmp_path):
+    class _NoLayers(_FakeClient):
+        def list_layers(self):
+            return []
+
+    df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
+    with pytest.raises(VectorTileError):
+        build_points_pmtiles_layer(
+            df, {}, dest_dir=str(tmp_path), client_factory=lambda **k: _NoLayers(**k)
+        )
+
+
+def test_build_points_layer_client_error_wrapped(tmp_path):
+    def boom(**k):
+        raise RuntimeError("tippecanoe missing")
+
+    df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
+    with pytest.raises(VectorTileError):
+        build_points_pmtiles_layer(df, {}, dest_dir=str(tmp_path), client_factory=boom)
+
+
+@pytest.mark.skipif(
+    __import__("shutil").which("tippecanoe") is None, reason="tippecanoe not installed"
+)
+def test_build_points_layer_real(tmp_path):
+    df = pd.DataFrame(
+        {
+            "longitude": [0.0, 0.001, 0.002],
+            "latitude": [0.0, 0.001, 0.002],
+            "map_code": [1, 1, 2],
+        }
+    )
+    try:
+        layer = build_points_pmtiles_layer(df, {1: "#111111"}, dest_dir=str(tmp_path))
+    except VectorTileError as e:
+        pytest.skip(f"tile library unavailable: {e}")
+    assert layer is not None

--- a/tests/test_vector_tiles.py
+++ b/tests/test_vector_tiles.py
@@ -170,3 +170,21 @@ def test_build_layer_or_notify_failure_notifies(monkeypatch):
     df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
     assert build_layer_or_notify(_MapBoom(), df, {}) is None
     assert errs and "Could not render sample points" in errs[0]
+
+
+class _MapNonVectorTileBoom:
+    def build_sample_points_layer(self, df, colors):
+        # e.g. tempfile.mkdtemp() failing with a raw OSError (disk full /
+        # quota) before build_points_pmtiles_layer -- and its VectorTileError
+        # wrapping -- is ever reached.
+        raise OSError("disk full")
+
+
+def test_build_layer_or_notify_non_vector_tile_error_notifies(monkeypatch):
+    from component.model import app_state as real_app_state
+
+    errs = []
+    monkeypatch.setattr(real_app_state, "add_error", lambda msg: errs.append(msg))
+    df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
+    assert build_layer_or_notify(_MapNonVectorTileBoom(), df, {}) is None
+    assert errs and "Could not render sample points" in errs[0]

--- a/ui.ipynb
+++ b/ui.ipynb
@@ -16,13 +16,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": " (venv) sbae-design",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "venv-sbae-design"
+   "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.12"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.4"
   }
  },
  "nbformat": 4,

--- a/ui.ipynb
+++ b/ui.ipynb
@@ -16,21 +16,13 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": " (venv) sbae-design",
    "language": "python",
-   "name": "python3"
+   "name": "venv-sbae-design"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.4"
+   "version": "3.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Folds in the unreviewed #12 (analysis results dashboard) and adds PMTiles sample-point rendering on top, so the full sample-design + accuracy-assessment feature lands in one PR to `main` instead of a stacked pair.

- Accuracy-assessment results dashboard (KPIs with a per-metric info tooltip, charts, tables), gated on an explicit Calculate.
- Sample points rendered as PMTiles vector tiles to scale to tens of thousands of points: uniform design dots; analysis reference points coloured green/red by agreement (correct/incorrect) with an on-map legend. protomaps-leaflet can't evaluate MapLibre colour expressions, so each value is its own flat circle layer behind an `==` filter.
- Point layers clear with their data and always draw above rasters.

Adds tippecanoe (conda-forge) + vectortileserver (pip) to `sepal_environment.yml`. Full test suite green (187 passed). Supersedes #12 — its commits are included here.
