### PR TITLE
Ensure tippecanoe is on PATH under SEPAL

### DIFF
--- a/component/scripts/vector_tiles.py
+++ b/component/scripts/vector_tiles.py
@@ -12,6 +12,7 @@ import asyncio
 import json
 import logging
 import os
+import sys
 from typing import Callable, Optional
 
 import pandas as pd
@@ -19,6 +20,25 @@ import pandas as pd
 from component.scripts.logging_config import quiet_tile_server_logs
 
 logger = logging.getLogger("sbae.vector_tiles")
+
+
+def _ensure_tippecanoe_on_path() -> None:
+    """Put the interpreter's own ``bin/`` on PATH so tippecanoe is found.
+
+    ``vectortileserver`` invokes ``tippecanoe`` by bare name via subprocess, so
+    it relies on PATH. Under SEPAL the app runs from a micromamba venv launched
+    by absolute path, so that venv's ``bin/`` -- where the conda-forge tippecanoe
+    lives, right next to ``sys.executable`` -- is NOT on PATH and the lookup
+    fails. Prepend it when the binary is actually there; idempotent, and a
+    harmless no-op when tippecanoe isn't a sibling of the interpreter.
+    """
+    bindir = os.path.dirname(sys.executable)
+    if not bindir or not os.path.exists(os.path.join(bindir, "tippecanoe")):
+        return
+    parts = os.environ.get("PATH", "").split(os.pathsep)
+    if bindir not in parts:
+        os.environ["PATH"] = os.pathsep.join([bindir, *parts])
+
 
 # Point styling. Sample/reference points stay a single neutral colour with a
 # white halo so they read over a colourful classification map; analysis points
@@ -176,6 +196,10 @@ async def _default_layer_factory(
     on the event loop, returning a layer that already knows its own ``.bounds``.
     """
     import vectortileserver as vts
+
+    # vectortileserver shells out to `tippecanoe` by name -> ensure the venv's
+    # bin (where the conda tippecanoe sits) is on PATH before it runs.
+    _ensure_tippecanoe_on_path()
 
     workspace = vts.TileWorkspace(allowed_directories=allowed_directories)
     return await workspace.open_async(

--- a/tests/test_vector_tiles.py
+++ b/tests/test_vector_tiles.py
@@ -1,4 +1,6 @@
 import asyncio
+import os
+import sys
 
 import pandas as pd
 import pytest
@@ -6,6 +8,7 @@ import pytest
 from component.scripts.vector_tiles import (
     POINT_CONVERSION_OPTIONS,
     VectorTileError,
+    _ensure_tippecanoe_on_path,
     build_layer_or_notify,
     build_point_style,
     build_points_pmtiles_layer,
@@ -47,6 +50,31 @@ def test_points_to_geojson_omits_absent_props():
 def test_points_to_geojson_empty_df():
     fc = points_to_geojson(pd.DataFrame({"longitude": [], "latitude": []}))
     assert fc["features"] == []
+
+
+def test_ensure_tippecanoe_on_path_prepends_bin(monkeypatch, tmp_path):
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "tippecanoe").write_text("")  # pretend the binary is installed here
+    monkeypatch.setattr(sys, "executable", str(bindir / "python3"))
+    monkeypatch.setenv("PATH", "/usr/bin")
+
+    _ensure_tippecanoe_on_path()
+    parts = os.environ["PATH"].split(os.pathsep)
+    assert parts[0] == str(bindir)  # venv bin prepended so `tippecanoe` resolves
+    # idempotent: a second call must not duplicate the entry
+    _ensure_tippecanoe_on_path()
+    assert os.environ["PATH"].split(os.pathsep).count(str(bindir)) == 1
+
+
+def test_ensure_tippecanoe_on_path_noop_when_absent(monkeypatch, tmp_path):
+    bindir = tmp_path / "bin"
+    bindir.mkdir()  # no tippecanoe sibling
+    monkeypatch.setattr(sys, "executable", str(bindir / "python3"))
+    monkeypatch.setenv("PATH", "/usr/bin")
+
+    _ensure_tippecanoe_on_path()
+    assert os.environ["PATH"] == "/usr/bin"  # untouched
 
 
 def test_build_point_style_emits_flat_layer_per_class():


### PR DESCRIPTION
vectortileserver runs `tippecanoe` by bare name, so it relies on PATH. Under
SEPAL the app runs from a micromamba venv launched by absolute path, so that
venv's `bin/` -- where the conda-forge tippecanoe lives, next to
`sys.executable` -- is not on PATH and the PMTiles point build fails with
"Tippecanoe executable not found".

Prepend the interpreter's own `bin/` to PATH (only when a `tippecanoe` sibling
is actually there) right before conversion. Idempotent and a no-op locally,
where tippecanoe is already on PATH.

Follows #13 (now on main).
