### PR TITLE
Fix duplicate 'file uploaded and optimized' toast

### DIFF
--- a/component/tile/upload.py
+++ b/component/tile/upload.py
@@ -116,6 +116,29 @@ def CurrentFileDisplay(sbae_map: SbaeMap = None):
         )
 
 
+def _upload_toast(*, has_file, is_raster, state, value, error):
+    """Decide the terminal upload toast: ``(level, message)`` or ``None``.
+
+    The raster success toast fires only when the optimization produced a real
+    result (``value``), never on the idle/no-op ``FINISHED`` state of the
+    prep thread's ``lambda: None`` branch. That ambiguity -- the thread rests at
+    ``FINISHED`` before the real run starts -- is what fired the "optimized"
+    toast twice.
+    """
+    if not has_file:
+        return None
+    if not is_raster:
+        return ("success", "File uploaded successfully.")
+    if state == solara.ResultState.ERROR:
+        return ("error", f"Error optimizing raster: {error}")
+    if state == solara.ResultState.FINISHED and value:
+        return (
+            "success",
+            "File uploaded and optimized — you can now edit class names.",
+        )
+    return None
+
+
 @solara.component
 def UploadTile(sbae_map: SbaeMap):
     """Step 1: File Upload Dialog."""
@@ -201,20 +224,21 @@ def UploadTile(sbae_map: SbaeMap):
 
     def announce_upload_state():
         """Toast the terminal upload/optimization state (progress stays inline)."""
-        if not has_file:
+        toast = _upload_toast(
+            has_file=has_file,
+            is_raster=is_raster_file(app_state.file_path.value or ""),
+            state=raster_prep_result.state,
+            value=raster_prep_result.value,
+            error=raster_prep_result.error,
+        )
+        if toast is None:
             return
-        if is_raster_file(app_state.file_path.value or ""):
-            if raster_prep_result.state == solara.ResultState.ERROR:
-                logger.error("Raster optimization failed: %s", raster_prep_result.error)
-                notifications.error(
-                    f"Error optimizing raster: {raster_prep_result.error}"
-                )
-            elif raster_prep_result.state == solara.ResultState.FINISHED:
-                notifications.success(
-                    "File uploaded and optimized — you can now edit class names."
-                )
+        level, message = toast
+        if level == "error":
+            logger.error("Raster optimization failed: %s", raster_prep_result.error)
+            notifications.error(message)
         else:
-            notifications.success("File uploaded successfully.")
+            notifications.success(message)
 
     solara.use_effect(announce_upload_state, [has_file, raster_prep_result.state])
 

--- a/tests/test_upload_toast.py
+++ b/tests/test_upload_toast.py
@@ -1,0 +1,68 @@
+"""_upload_toast: the terminal upload/optimization toast decision.
+
+Guards the duplicate "optimized" toast: the raster success must fire only when a
+real optimization result exists, not on the prep thread's idle FINISHED state.
+"""
+
+import solara
+
+from component.tile.upload import _upload_toast
+
+_R = solara.ResultState
+
+
+def test_no_file_no_toast():
+    assert (
+        _upload_toast(
+            has_file=False, is_raster=True, state=_R.FINISHED, value=None, error=None
+        )
+        is None
+    )
+
+
+def test_non_raster_success():
+    level, msg = _upload_toast(
+        has_file=True, is_raster=False, state=_R.FINISHED, value=None, error=None
+    )
+    assert level == "success"
+    assert msg == "File uploaded successfully."
+
+
+def test_raster_error():
+    level, msg = _upload_toast(
+        has_file=True, is_raster=True, state=_R.ERROR, value=None, error="boom"
+    )
+    assert level == "error"
+    assert "boom" in msg
+
+
+def test_raster_optimized_only_with_real_result():
+    level, msg = _upload_toast(
+        has_file=True,
+        is_raster=True,
+        state=_R.FINISHED,
+        value={"path": "/tmp/opt.tif"},
+        error=None,
+    )
+    assert level == "success"
+    assert "optimized" in msg
+
+
+def test_raster_finished_without_result_is_silent():
+    # The no-op / idle FINISHED (lambda: None) must NOT toast -- this is the
+    # duplicate-toast regression.
+    assert (
+        _upload_toast(
+            has_file=True, is_raster=True, state=_R.FINISHED, value=None, error=None
+        )
+        is None
+    )
+
+
+def test_raster_running_is_silent():
+    assert (
+        _upload_toast(
+            has_file=True, is_raster=True, state=_R.RUNNING, value=None, error=None
+        )
+        is None
+    )


### PR DESCRIPTION
The raster-prep thread rests at `FINISHED` (its `lambda: None` idle branch) before the real optimization runs. When `has_file` flips true the announce effect toasted once on that idle `FINISHED` and again on the real completion — two toasts.

Gate the raster success toast on an actual optimization result (`raster_prep_result.value`), extracted into a pure, tested `_upload_toast` helper. No toast on the idle/no-op FINISHED; other cases (non-raster success, error) unchanged.