### PR TITLE
Bind the PMTiles tile server to 127.0.0.1 (IPv4)

### DIFF
--- a/component/scripts/vector_tiles.py
+++ b/component/scripts/vector_tiles.py
@@ -201,7 +201,13 @@ async def _default_layer_factory(
     # bin (where the conda tippecanoe sits) is on PATH before it runs.
     _ensure_tippecanoe_on_path()
 
-    workspace = vts.TileWorkspace(allowed_directories=allowed_directories)
+    # Bind the tile server to IPv4 loopback explicitly. The default "localhost"
+    # can resolve to IPv6 ::1, which some sandboxes (SEPAL) can't assign -> the
+    # server fails to bind and never starts. 127.0.0.1 is also the exact form
+    # jupyter_loopback's interceptor matches.
+    workspace = vts.TileWorkspace(
+        host="127.0.0.1", allowed_directories=allowed_directories
+    )
     return await workspace.open_async(
         source, style=style, conversion_options=conversion_options
     )

--- a/tests/test_vector_tiles.py
+++ b/tests/test_vector_tiles.py
@@ -41,6 +41,39 @@ def test_points_to_geojson_emits_multiple_code_props():
     assert props["ref_code"] == 4 and isinstance(props["ref_code"], int)
 
 
+def test_default_layer_factory_binds_ipv4_loopback(monkeypatch):
+    import types
+
+    from component.scripts import vector_tiles as vt
+
+    captured = {}
+
+    class _FakeWorkspace:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        async def open_async(self, source, *, style, conversion_options):
+            return "LAYER"
+
+    monkeypatch.setattr(vt, "_ensure_tippecanoe_on_path", lambda: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "vectortileserver",
+        types.SimpleNamespace(TileWorkspace=_FakeWorkspace),
+    )
+    layer = asyncio.run(
+        vt._default_layer_factory(
+            "src.geojson",
+            style=lambda *a: {},
+            conversion_options={},
+            allowed_directories=["/tmp/x"],
+        )
+    )
+    assert layer == "LAYER"
+    # localhost can resolve to IPv6 ::1, unbindable in some sandboxes (SEPAL)
+    assert captured["host"] == "127.0.0.1"
+
+
 def test_points_to_geojson_omits_absent_props():
     df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0]})  # no map_code
     fc = points_to_geojson(df)


### PR DESCRIPTION
On SEPAL the tile server fails to start: `error while attempting to bind on address ('::1', 8000): cannot assign requested address` -> `TimeoutError: Server failed to start`.

vectortileserver defaults its host to `localhost`, which resolves to IPv6 `::1` on that container, and the sandbox has no assignable IPv6 loopback. Bind the tile server to `127.0.0.1` explicitly in the tile-factory seam. As a bonus, `127.0.0.1` is the exact host form jupyter_loopback's interceptor matches.

Follows #16.