### PR TITLE
fix: keep scratch dirs off NFS

### DIFF
--- a/component/model/state_manager.py
+++ b/component/model/state_manager.py
@@ -4,12 +4,12 @@ Contains reactive state management for the SBAE application.
 """
 
 import json
-import tempfile
 from typing import Dict, List
 
 import geopandas as gpd
 import pandas as pd
 import solara
+from pysepal.scripts.scratch import scratch_dir
 
 from component.scripts.precision import calculate_current_moe
 
@@ -20,7 +20,7 @@ class AppState:
     def __init__(self):
         # File handling
         self.uploaded_file_info = solara.reactive(None)
-        self.temp_dir = solara.reactive(tempfile.mkdtemp())
+        self.temp_dir = solara.reactive(str(scratch_dir(prefix="sbae_")))
         self.file_path = solara.reactive(None)
         self.file_error = solara.reactive(None)
 

--- a/component/scripts/geospatial.py
+++ b/component/scripts/geospatial.py
@@ -4,7 +4,6 @@ Contains functions for file I/O, area calculation, and point generation.
 """
 
 import os
-import tempfile
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -12,6 +11,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import rasterio
+from pysepal.scripts.scratch import scratch_dir
 from rasterio.transform import xy
 from rasterio.warp import transform as warp_transform
 from rasterio.windows import Window
@@ -405,7 +405,7 @@ def save_uploaded_file(file_info, temp_dir: Optional[str] = None) -> str:
         Path to saved file
     """
     if temp_dir is None:
-        temp_dir = tempfile.mkdtemp()
+        temp_dir = str(scratch_dir(prefix="sbae_upload_"))
 
     file_path = os.path.join(temp_dir, file_info["name"])
 

--- a/component/scripts/vector_tiles.py
+++ b/component/scripts/vector_tiles.py
@@ -320,8 +320,8 @@ async def build_layer_or_notify(sbae_map, points_df):
         # from the point-generation worker thread. Any failure here -- not just
         # VectorTileError -- must be swallowed and reported, never raised, or
         # the worker thread dies before it can hand the already-generated
-        # points back to the app (see build_sample_points_layer's mkdtemp call,
-        # which can raise a raw OSError outside build_points_pmtiles_layer's
+        # points back to the app (see build_sample_points_layer's scratch_dir
+        # call, which can raise a raw OSError outside build_points_pmtiles_layer's
         # own try/except).
         logger.warning("Sample points layer failed: %s", e)
         app_state.add_error(f"Could not render sample points on the map: {e}")

--- a/component/widget/map.py
+++ b/component/widget/map.py
@@ -245,8 +245,6 @@ class SbaeMap(SepalMap):
         """
         if points_data is None or points_data.empty:
             return None
-        # local disk, not the NFS /tmp: tippecanoe scratches alongside its output,
-        # so this directory decides how long the conversion takes
         dest_dir = str(scratch_dir(prefix="sbae_points_"))
         try:
             layer = await build_points_pmtiles_layer(

--- a/component/widget/map.py
+++ b/component/widget/map.py
@@ -1,11 +1,11 @@
 import logging
 import os
 import shutil
-import tempfile
 
 import pandas as pd
 import solara
 from localtileserver import TileClient, get_leaflet_tile_layer
+from pysepal.scripts.scratch import scratch_dir
 from sepal_ui.mapping import SepalMap
 from sepal_ui.sepalwidgets.vue_app import ThemeToggle
 
@@ -245,7 +245,9 @@ class SbaeMap(SepalMap):
         """
         if points_data is None or points_data.empty:
             return None
-        dest_dir = tempfile.mkdtemp(prefix="sbae_points_")
+        # local disk, not the NFS /tmp: tippecanoe scratches alongside its output,
+        # so this directory decides how long the conversion takes
+        dest_dir = str(scratch_dir(prefix="sbae_points_"))
         try:
             layer = await build_points_pmtiles_layer(
                 points_data,

--- a/sepal_environment.yml
+++ b/sepal_environment.yml
@@ -30,7 +30,9 @@ dependencies:
       - git+https://github.com/openforis/earthengine-api.git@v1.6.14#egg=earthengine-api&subdirectory=python
       - ipecharts>=1.0.0
       - voila
-      # local vector-tile server for the PMTiles map sample-points layer
-      - vectortileserver>=0.2
+      # local vector-tile server for the PMTiles map sample-points layer.
+      # >=0.2.1 hands tippecanoe a --temporary-directory: without it tippecanoe
+      # scratches in /tmp, which is NFS here, and that dominates tile generation.
+      - vectortileserver>=0.2.1
       # tile comm bridge (vectortileserver dep); pinned so it's never dropped
       - jupyter-loopback[comm]>=0.3.3

--- a/sepal_environment.yml
+++ b/sepal_environment.yml
@@ -24,15 +24,11 @@ dependencies:
   # tippecanoe builds the PMTiles vector tiles for the map sample-points layer.
   - tippecanoe>=2
   - pip:
-      # pysepal is the renamed sepal_ui; main has the notification system.
-      # The `sepal_ui` import path still works via a compatibility shim.
-      - git+https://github.com/openforis/pysepal.git
+      - pysepal>=3.8.1
       - git+https://github.com/openforis/earthengine-api.git@v1.6.14#egg=earthengine-api&subdirectory=python
       - ipecharts>=1.0.0
       - voila
-      # local vector-tile server for the PMTiles map sample-points layer.
-      # >=0.2.1 hands tippecanoe a --temporary-directory: without it tippecanoe
-      # scratches in /tmp, which is NFS here, and that dominates tile generation.
+      # local vector-tile server for the PMTiles map sample-points layer
       - vectortileserver>=0.2.1
       # tile comm bridge (vectortileserver dep); pinned so it's never dropped
       - jupyter-loopback[comm]>=0.3.3

--- a/tests/test_map_sample_points.py
+++ b/tests/test_map_sample_points.py
@@ -113,14 +113,14 @@ def test_attach_removes_previous_backing_dir(tmp_path):
 def test_build_cleans_dir_on_failure(monkeypatch, tmp_path):
     built_dir = tmp_path / "built"
 
-    def fake_mkdtemp(prefix=""):
+    def fake_scratch_dir(prefix=""):
         built_dir.mkdir()
-        return str(built_dir)
+        return built_dir
 
     async def boom(df, colors, *, dest_dir, default_color="#888888", **kwargs):
         raise VectorTileError("nope")
 
-    monkeypatch.setattr(map_mod.tempfile, "mkdtemp", fake_mkdtemp)
+    monkeypatch.setattr(map_mod, "scratch_dir", fake_scratch_dir)
     monkeypatch.setattr(map_mod, "build_points_pmtiles_layer", boom)
     df = pd.DataFrame({"longitude": [1.0], "latitude": [2.0], "map_code": [3]})
 

--- a/tests/test_vector_tiles.py
+++ b/tests/test_vector_tiles.py
@@ -326,8 +326,8 @@ def test_build_layer_or_notify_failure_notifies(monkeypatch):
 
 class _MapNonVectorTileBoom:
     async def build_sample_points_layer(self, df, *args, **kwargs):
-        # e.g. tempfile.mkdtemp() failing with a raw OSError (disk full /
-        # quota) before build_points_pmtiles_layer -- and its VectorTileError
+        # e.g. scratch_dir() failing with a raw OSError (disk full / quota)
+        # before build_points_pmtiles_layer -- and its VectorTileError
         # wrapping -- is ever reached.
         raise OSError("disk full")
 


### PR DESCRIPTION
`tempfile.mkdtemp()` resolves to `/tmp`, which on a SEPAL sandbox is an nfs4 mount of the home export — slow for many small writes, and counted against the storage quota. The sample-points layer feels it most: tippecanoe scratches alongside its output, so the directory `build_sample_points_layer` picks decides how long tile generation takes. Profiling a sandbox, 1000 points took 28.3s with the scratch on NFS and 0.44s with it on local disk, and the cost tracks tile count rather than point count, so small designs pay the same.

Routes the three temp dirs (`map.py`, `state_manager.py`, `geospatial.py`) through pysepal's `scratch_dir()`, which prefers container-local `/var/tmp` on SEPAL and the standard temp dir everywhere else. Also bumps `vectortileserver` to `>=0.2.1`: that release passes tippecanoe `--temporary-directory`, without which only the output moves and generation stays slow.

**Blocked on a publish:** vectortileserver 0.2.1 is tagged on GitHub but not yet on PyPI, so the environment build — and therefore CI — will fail until it is. pysepal 3.8.1 (which ships `pysepal.scripts.scratch`) is released, and the env already tracks pysepal main.

198 tests pass locally. One test that monkeypatched `map_mod.tempfile.mkdtemp` now patches `scratch_dir`; two comments naming `mkdtemp` were updated.